### PR TITLE
Added test case for mutually exclusive options. Fixed thrown exception

### DIFF
--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/MutuallyExclusiveRestriction.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/MutuallyExclusiveRestriction.java
@@ -15,12 +15,14 @@
  */
 package com.github.rvesse.airline.restrictions.options;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Transformer;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.github.rvesse.airline.help.sections.HelpFormat;
@@ -62,7 +64,7 @@ public class MutuallyExclusiveRestriction implements OptionRestriction, HelpHint
 
             // Otherwise may need to error
             if (parsedOptions.size() > 0 && otherParsedOptions.size() > parsedOptions.size()) {
-                Collection<OptionMetadata> taggedOptions = getTaggedOptions(state);
+                Collection<OptionMetadata> taggedOptions = selectMetadata(otherParsedOptions);
                 throw new ParseOptionGroupException(
                         "Only one of the following options may be specified but %d were found: %s", tag, taggedOptions,
                         otherParsedOptions.size(), toOptionsList(taggedOptions));
@@ -85,15 +87,13 @@ public class MutuallyExclusiveRestriction implements OptionRestriction, HelpHint
         }
         return builder.toString();
     }
-
-    private <T> Collection<OptionMetadata> getTaggedOptions(ParseState<T> state) {
-        List<OptionMetadata> options = state.getCommand() != null ? state.getCommand().getAllOptions() : null;
-        if (options == null)
-            options = state.getGroup() != null ? state.getGroup().getOptions() : null;
-        if (options == null)
-            options = state.getGlobal() != null ? state.getGlobal().getOptions()
-                    : Collections.<OptionMetadata> emptyList();
-        return CollectionUtils.select(options, new RequiredTagOptionFinder(this.tag));
+    
+    private Collection<OptionMetadata> selectMetadata(Collection<Pair<OptionMetadata, Object>> pairs){
+	ArrayList<OptionMetadata> metadata = new ArrayList<>();
+	for(Pair<OptionMetadata, Object> pair : pairs){
+	    metadata.add(pair.getLeft());
+	}
+	return metadata;
     }
 
     public String getTag() {

--- a/airline-core/src/test/java/com/github/rvesse/airline/MutuallyExclusiveOptions.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/MutuallyExclusiveOptions.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline; 
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.OptionType;
+import com.github.rvesse.airline.annotations.restrictions.MutuallyExclusiveWith;
+
+@Command(name = "MutuallyExclusiveOptionsCommand")
+public class MutuallyExclusiveOptions {
+
+  @Option(type = OptionType.COMMAND, name = { "-verbose" })
+  @MutuallyExclusiveWith(tag = "verbosity")
+  private boolean verbose;
+
+  @Option(type = OptionType.COMMAND, name = { "-quiet" })
+  @MutuallyExclusiveWith(tag = "verbosity")
+  private boolean quiet;
+  
+  @Option(type = OptionType.COMMAND, name = { "-other" })
+  private boolean other;
+}

--- a/airline-core/src/test/java/com/github/rvesse/airline/TestSingleCommand.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/TestSingleCommand.java
@@ -46,6 +46,7 @@ import com.github.rvesse.airline.command.CommandCommit;
 import com.github.rvesse.airline.model.CommandMetadata;
 import com.github.rvesse.airline.model.ParserMetadata;
 import com.github.rvesse.airline.parser.errors.ParseException;
+import com.github.rvesse.airline.parser.errors.ParseOptionGroupException;
 import com.github.rvesse.airline.parser.options.ClassicGetOptParser;
 import com.github.rvesse.airline.parser.options.StandardOptionParser;
 import com.github.rvesse.airline.utils.AirlineUtils;
@@ -479,5 +480,22 @@ public class TestSingleCommand {
 
         @Option(name = "-i", description = "Interactive add mode")
         public Boolean interactive = false;
+    }
+    
+    @Test(expectedExceptions = ParseOptionGroupException.class, description = "Verify that mutually exclusive options are found")
+    public void testMutuallyExclusiveOptions() {
+        singleCommand(MutuallyExclusiveOptions.class).parse("-verbose", "-quiet");
+    }
+    
+    @Test(description = "Verify that mutually exclusive options are present in the thrown ParseOptionGroupException")
+    public void testMutuallyExclusiveOptionsAreDescribedInException() {
+        try {
+            SingleCommand<MutuallyExclusiveOptions> command = singleCommand(MutuallyExclusiveOptions.class);
+            System.out.println(command.getCommandMetadata());
+	    command.parse("-verbose", "-quiet");
+            assertFalse(true);
+        } catch(ParseOptionGroupException expected){
+            assertEquals(expected.getMessage(), "Only one of the following options may be specified but 2 were found: -verbose, -quiet");
+        }
     }
 }

--- a/airline-core/src/test/java/com/github/rvesse/airline/TestSingleCommand.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/TestSingleCommand.java
@@ -491,7 +491,6 @@ public class TestSingleCommand {
     public void testMutuallyExclusiveOptionsAreDescribedInException() {
         try {
             SingleCommand<MutuallyExclusiveOptions> command = singleCommand(MutuallyExclusiveOptions.class);
-            System.out.println(command.getCommandMetadata());
 	    command.parse("-verbose", "-quiet");
             assertFalse(true);
         } catch(ParseOptionGroupException expected){


### PR DESCRIPTION
Hello there, a great library you have :+1: 

Now to the issue:
I noticed that when you annotate two options to be mutual exclusive, there, correctly, is an exception thrown if both of the options are set. However, the thrown exception is missing entries for the offending options, both in the message and in the Set of OptionMetadata contained within the exception. I think there might be a wrong filter applied when setting up the exception.

I wrote two testcases for this, and fixed it as best as my limited time at work and knowledge allowed. Maybe some stuff has to be moved and maybe the fix falls short for some other cases. Please have a look into it. 

Hoping for further suggestions,
GTarkin