### PR TITLE
added support for google guice

### DIFF
--- a/airline-core/pom.xml
+++ b/airline-core/pom.xml
@@ -34,6 +34,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
     </dependency>

--- a/airline-core/src/main/java/com/github/rvesse/airline/CommandContext.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/CommandContext.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline;
+
+import java.util.Map;
+
+/**
+ * The CommandContext provides the context for command creation and handles the injection of arguments, options and
+ * dependencies.
+ *
+ * @param <T> type of command
+ */
+public interface CommandContext<T> {
+
+    /**
+     * Returns bindings for injection.
+     *
+     * @return injection bindings
+     */
+    Map<Class<?>, Object> getBindings();
+
+    /**
+     * Process arguments of command instance.
+     *
+     * @param commandInstance command instance
+     */
+    void processArguments(T commandInstance);
+
+    /**
+     * Process options of command instance.
+     *
+     * @param commandInstance command instance
+     */
+    void processOptions(T commandInstance);
+
+    /**
+     * Process injections of command instance.
+     *
+     * @param commandInstance command instance
+     */
+    void processInjections(T commandInstance);
+}

--- a/airline-core/src/main/java/com/github/rvesse/airline/CommandFactory.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/CommandFactory.java
@@ -24,10 +24,11 @@ package com.github.rvesse.airline;
 public interface CommandFactory<T> {
     /**
      * Creates an instance of the given type
-     * 
+     *
+     * @param context context of command to be instantiated
      * @param type
      *            Type
      * @return Instance
      */
-    public abstract T createInstance(Class<?> type);
+    public abstract T createInstance(CommandContext<T> context, Class<?> type);
 }

--- a/airline-core/src/main/java/com/github/rvesse/airline/DefaultCommandFactory.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/DefaultCommandFactory.java
@@ -21,8 +21,12 @@ public class DefaultCommandFactory<T> implements CommandFactory<T> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public T createInstance(Class<?> type) {
-        return (T) ParserUtil.createInstance(type);
+    public T createInstance(CommandContext<T> context, Class<?> type) {
+        T instance = (T) ParserUtil.createInstance(type);
+        context.processArguments(instance);
+        context.processOptions(instance);
+        context.processInjections(instance);
+        return instance;
     }
 
 }

--- a/airline-core/src/main/java/com/github/rvesse/airline/HelpOption.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/HelpOption.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Option;
@@ -41,6 +42,7 @@ public class HelpOption<C> {
     private GlobalMetadata<C> globalMetadata;
 
     @Inject
+    @Nullable // require for the guice module
     private CommandGroupMetadata groupMetadata;
 
     @Inject
@@ -54,7 +56,7 @@ public class HelpOption<C> {
     /**
      * Shows help if user requested it and it hasn't already been shown using
      * the default {@link CliCommandUsageGenerator}
-     * 
+     *
      * @return True if help was requested by the user
      */
     public boolean showHelpIfRequested() {
@@ -63,7 +65,7 @@ public class HelpOption<C> {
 
     /**
      * Shows help if user requested it and it hasn't already been shown
-     * 
+     *
      * @param generator
      *            Usage generator
      * @return True if help was requested by the user
@@ -79,7 +81,7 @@ public class HelpOption<C> {
     /**
      * Shows help if any parsing errors were detected. If errors were detected
      * the error messages are printed prior to the help
-     * 
+     *
      * @param result
      *            Parsing result, if {@code null} then this method does nothing
      * @param <T>
@@ -92,7 +94,7 @@ public class HelpOption<C> {
 
     /**
      * Shows help if any parsing errors were detected
-     * 
+     *
      * @param result
      *            Parsing result, if {@code null} then this method does nothing
      * @param printErrors
@@ -108,7 +110,7 @@ public class HelpOption<C> {
 
     /**
      * Shows help if any parsing errors were detected
-     * 
+     *
      * @param result
      *            Parsing result, if {@code null} then this method does nothing
      * @param printErrors
@@ -154,7 +156,7 @@ public class HelpOption<C> {
 
     /**
      * Shows help using the given usage generator
-     * 
+     *
      * @param generator
      *            Usage generator
      */

--- a/airline-core/src/main/java/com/github/rvesse/airline/parser/DefaultCommandContext.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/parser/DefaultCommandContext.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline.parser;
+
+import com.github.rvesse.airline.Accessor;
+import com.github.rvesse.airline.CommandContext;
+import com.github.rvesse.airline.model.ArgumentsMetadata;
+import com.github.rvesse.airline.model.OptionMetadata;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public final class DefaultCommandContext<T> implements CommandContext<T> {
+
+    private Iterable<OptionMetadata> options;
+    private List<Pair<OptionMetadata, Object>> parsedOptions;
+    private ArgumentsMetadata arguments;
+    private Iterable<Object> parsedArguments;
+    private Iterable<Accessor> metadataInjection;
+    private Map<Class<?>, Object> bindings;
+
+    DefaultCommandContext(Iterable<OptionMetadata> options, List<Pair<OptionMetadata, Object>> parsedOptions, ArgumentsMetadata arguments, Iterable<Object> parsedArguments, Iterable<Accessor> metadataInjection, Map<Class<?>, Object> bindings) {
+        this.options = options;
+        this.parsedOptions = parsedOptions;
+        this.arguments = arguments;
+        this.parsedArguments = parsedArguments;
+        this.metadataInjection = metadataInjection;
+        this.bindings = bindings;
+    }
+
+    @Override
+    public Map<Class<?>, Object> getBindings() {
+        return bindings;
+    }
+
+    @Override
+    public void processArguments(T commandInstance) {
+        if (arguments != null && parsedArguments != null) {
+            for (Accessor accessor : arguments.getAccessors()) {
+                accessor.addValues(commandInstance, parsedArguments);
+            }
+        }
+    }
+
+    @Override
+    public void processOptions(T commandInstance) {
+        for (OptionMetadata option : options) {
+            List<Object> values = new ArrayList<>();
+            for (Pair<OptionMetadata, Object> parsedOption : parsedOptions) {
+                if (option.equals(parsedOption.getLeft()))
+                    values.add(parsedOption.getRight());
+            }
+            if (values != null && !values.isEmpty()) {
+                for (Accessor accessor : option.getAccessors()) {
+                    accessor.addValues(commandInstance, values);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void processInjections(T commandInstance) {
+        for (Accessor accessor : metadataInjection) {
+            Object injectee = bindings.get(accessor.getJavaType());
+
+            if (injectee != null) {
+                accessor.addValues(commandInstance, ListUtils.unmodifiableList(Collections.singletonList(injectee)));
+            }
+        }
+    }
+}

--- a/airline-guice/pom.xml
+++ b/airline-guice/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>airline-parent</artifactId>
+        <groupId>com.github.rvesse</groupId>
+        <version>2.5.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>airline-guice</artifactId>
+    <name>Airline - Guice</name>
+    <description>Provides Guice support for airline</description>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>airline</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <properties>
+        <license.header.path>${project.parent.basedir}</license.header.path>
+        <coveralls.skip>true</coveralls.skip>
+    </properties>
+
+</project>

--- a/airline-guice/src/main/java/com/github/rvesse/airline/guice/CommandModule.java
+++ b/airline-guice/src/main/java/com/github/rvesse/airline/guice/CommandModule.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline.guice;
+
+import com.github.rvesse.airline.CommandContext;
+import com.github.rvesse.airline.model.CommandGroupMetadata;
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.util.Providers;
+import com.google.inject.util.Types;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.Map;
+
+/**
+ * Guice module to bind injection bindings to google guice binder.
+ *
+ * @param <T> type of commands
+ */
+final class CommandModule<T> extends AbstractModule {
+
+    private final Class<T> type;
+    private final CommandContext<T> context;
+
+    CommandModule(Class<T> type, CommandContext<T> context) {
+        this.type = type;
+        this.context = context;
+    }
+
+    @Override
+    protected void configure() {
+        Map<Class<?>, Object> bindings = context.getBindings();
+        for (Map.Entry<Class<?>, Object> entry : bindings.entrySet()) {
+            bindBinding(entry.getKey(), entry.getValue());
+        }
+
+        if (!bindings.containsKey(CommandGroupMetadata.class)) {
+            bind(CommandGroupMetadata.class).toProvider(Providers.<CommandGroupMetadata>of(null));
+        }
+    }
+
+    private <I> void bindBinding(Class<I> bindingType, Object instance) {
+        ParameterizedType parameterizedType = Types.newParameterizedType(bindingType, type);
+        bindBinding(Key.get(parameterizedType), instance);
+        bind(bindingType).toInstance((I) instance);
+    }
+
+    private <I> void bindBinding(Key<I> key, Object value) {
+        bind(key).toInstance((I) value);
+    }
+
+}

--- a/airline-guice/src/main/java/com/github/rvesse/airline/guice/GuiceCommandFactory.java
+++ b/airline-guice/src/main/java/com/github/rvesse/airline/guice/GuiceCommandFactory.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline.guice;
+
+import com.github.rvesse.airline.CommandContext;
+import com.github.rvesse.airline.CommandFactory;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.util.Types;
+
+import java.lang.reflect.ParameterizedType;
+
+/**
+ * Command factory which uses google guice for the creation of commands and for dependency injection.
+ *
+ * @param <T> type of commands
+ */
+public class GuiceCommandFactory<T> implements CommandFactory<T> {
+
+    private final Class<T> commandType;
+    private final Injector injector;
+
+    /**
+     * Creates a new GuiceCommandFactory
+     *
+     * @param commandType type of commands
+     * @param injector google guice parent injector
+     */
+    public GuiceCommandFactory(Class<T> commandType, Injector injector) {
+        this.commandType = commandType;
+        this.injector = injector;
+    }
+
+    @Override
+    public T createInstance(CommandContext<T> context, Class<?> command) {
+        Injector commandInjector = createCommandInjector(context);
+        Key<T> key = createKey(command);
+
+        T commandInstance = commandInjector.getInstance(key);
+        context.processArguments(commandInstance);
+        context.processOptions(commandInstance);
+        return commandInstance;
+    }
+
+    private Injector createCommandInjector(CommandContext<T> context) {
+        return injector.createChildInjector(new CommandModule<>(commandType, context));
+    }
+
+    private Key<T> createKey(Class<?> command) {
+        ParameterizedType parameterizedType;
+        Class<?> enclosingClass = command.getEnclosingClass();
+        if (enclosingClass != null) {
+            parameterizedType = Types.newParameterizedTypeWithOwner(enclosingClass, command, commandType);
+        } else {
+            parameterizedType = Types.newParameterizedType(command, commandType);
+        }
+
+        return (Key<T>) Key.get(parameterizedType);
+    }
+}

--- a/airline-guice/src/test/java/com/github/rvesse/airline/guice/GuiceTest.java
+++ b/airline-guice/src/test/java/com/github/rvesse/airline/guice/GuiceTest.java
@@ -1,0 +1,39 @@
+package com.github.rvesse.airline.guice;
+
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class GuiceTest {
+
+    @Test
+    public void test() {
+        assertOutput(
+                Lists.newArrayList("repositories", "list"),
+                Lists.newArrayList("repositories", "-> airline", "-> scm-manager", "-> jenkins")
+        );
+        assertOutput(
+                Lists.newArrayList("repositories", "add", "--type", "git", "airline"),
+                Lists.newArrayList("=> add repository: git/airline")
+        );
+        assertOutput(
+                Lists.newArrayList("whoami"),
+                Lists.newArrayList("=> root")
+        );
+        assertOutput(
+                Lists.newArrayList("app"),
+                Lists.newArrayList("=> assertOutput")
+        );
+    }
+
+    private void assertOutput(List<String> args, List<String> expectedOutput) {
+        Output output = new Output();
+        Sample.main(output, args.toArray(new String[0]));
+
+        assertEquals(output.getLines(), expectedOutput);
+    }
+
+}

--- a/airline-guice/src/test/java/com/github/rvesse/airline/guice/Output.java
+++ b/airline-guice/src/test/java/com/github/rvesse/airline/guice/Output.java
@@ -1,0 +1,18 @@
+package com.github.rvesse.airline.guice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Output {
+
+    private List<String> lines = new ArrayList<>();
+
+    public void println(String line) {
+        lines.add(line);
+    }
+
+    public List<String> getLines() {
+        return lines;
+    }
+
+}

--- a/airline-guice/src/test/java/com/github/rvesse/airline/guice/Sample.java
+++ b/airline-guice/src/test/java/com/github/rvesse/airline/guice/Sample.java
@@ -1,0 +1,140 @@
+package com.github.rvesse.airline.guice;
+
+import com.github.rvesse.airline.Cli;
+import com.github.rvesse.airline.CommandFactory;
+import com.github.rvesse.airline.HelpOption;
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
+import com.github.rvesse.airline.builder.CliBuilder;
+import com.github.rvesse.airline.help.Help;
+import com.github.rvesse.airline.model.GlobalMetadata;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Sample {
+
+    public static void main(Output output, String... args) {
+        Injector injector = Guice.createInjector(new SampleModule(output));
+        CommandFactory<Runnable> commandFactory = new GuiceCommandFactory<>(Runnable.class, injector);
+
+        CliBuilder<Runnable> builder = Cli.<Runnable>builder("sample")
+                .withDescription("sample application")
+                .withDefaultCommand(Help.class)
+                .withCommand(ApplicationName.class)
+                .withCommands(Help.class, ListRepositories.class, AddRepository.class, WhoamiCommand.class);
+
+        builder.withParser()
+                .withCommandFactory(commandFactory);
+
+        Cli<Runnable> sampleParser = builder.build();
+
+        sampleParser.parse(args).run();
+    }
+
+    public static class SampleModule extends AbstractModule {
+
+        private final Output output;
+
+        SampleModule(Output output) {
+            this.output = output;
+        }
+
+        @Override
+        protected void configure() {
+            List<String> repositories = new ArrayList<>();
+            repositories.add("airline");
+            repositories.add("scm-manager");
+            repositories.add("jenkins");
+
+            bind(new TypeLiteral<List<String>>(){}).annotatedWith(Names.named("repositories")).toInstance(repositories);
+            bind(Output.class).toInstance(output);
+        }
+    }
+
+    public static abstract class SampleCommand implements Runnable {
+
+        @Inject
+        private HelpOption<Runnable> helpOption;
+
+        @Override
+        public void run() {
+            if (helpOption.showHelpIfRequested()) {
+                helpOption.showHelp();
+            } else {
+                execute();
+            }
+        }
+
+        protected abstract void execute();
+    }
+
+    @Command(name = "app")
+    public static class ApplicationName<T> extends SampleCommand {
+
+        private GlobalMetadata<T> metadata;
+        private final Output output;
+
+        @Inject
+        public ApplicationName(GlobalMetadata<T> metadata, Output output) {
+            this.metadata = metadata;
+            this.output = output;
+        }
+
+        @Override
+        protected void execute() {
+            output.println("=> " + metadata.getName());
+        }
+    }
+
+    @Command(name = "list", groupNames = "repositories")
+    public static class ListRepositories extends SampleCommand {
+
+        private final Output output;
+        private final List<String> repositories;
+
+        @Inject
+        public ListRepositories(Output output, @Named("repositories") List<String> repositories) {
+            this.output = output;
+            this.repositories = repositories;
+        }
+
+        @Override
+        protected void execute() {
+            output.println("repositories");
+            for (String repository : repositories) {
+                output.println("-> " + repository);
+            }
+        }
+    }
+
+    @Command(name = "add", groupNames = "repositories")
+    public static class AddRepository extends SampleCommand {
+
+        @Required
+        @Option(name = {"--type", "-t"})
+        private String type;
+
+        @Required
+        @Arguments
+        private String name;
+
+        @Inject
+        private Output output;
+
+        @Override
+        protected void execute() {
+            output.println("=> add repository: " + type + "/" + name);
+        }
+    }
+
+}

--- a/airline-guice/src/test/java/com/github/rvesse/airline/guice/WhoamiCommand.java
+++ b/airline-guice/src/test/java/com/github/rvesse/airline/guice/WhoamiCommand.java
@@ -1,0 +1,21 @@
+package com.github.rvesse.airline.guice;
+
+import com.github.rvesse.airline.annotations.Command;
+
+import javax.inject.Inject;
+
+@Command(name = "whoami")
+public class WhoamiCommand implements Runnable {
+
+    private final Output output;
+
+    @Inject
+    public WhoamiCommand(Output output) {
+        this.output = output;
+    }
+
+    @Override
+    public void run() {
+        output.println("=> root");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,13 @@
     <dependency.testng>6.8.8</dependency.testng>
     <dependency.commons-lang3>3.3.2</dependency.commons-lang3>
     <dependency.commons-collections4>4.0</dependency.commons-collections4>
+    <dependency.guice>4.1.0</dependency.guice>
+    <dependency.jsr305>3.0.2</dependency.jsr305>
   </properties>
 
   <modules>
     <module>airline-core</module>
+    <module>airline-guice</module>
     <module>airline-examples</module>
     <module>airline-io</module>
     <module>airline-help</module>
@@ -104,6 +107,18 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
         <version>${dependency.commons-collections4}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>${dependency.jsr305}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>${dependency.guice}</version>
       </dependency>
 
       <!-- for testing -->
@@ -295,7 +310,7 @@
     <!-- M2E Configuration -->
     <pluginManagement>
       <plugins>
-        <!--This plugin's configuration is used to store Eclipse m2e settings 
+        <!--This plugin's configuration is used to store Eclipse m2e settings
           only. It has no influence on the Maven build itself. -->
         <plugin>
           <groupId>org.eclipse.m2e</groupId>


### PR DESCRIPTION
Hi,
first of all thank you for the fantastic library. I've tried to use airline with google guice to create the commands, but guice fails because of a conflict with the Inject annotation of airline.

So i've build a module which populates the bindings of airline to google guice, so guice can be used to create the commands and handles the injection. But in order to implement the module, i've need to pass the context of the command to the CommandFactory for the creation. I know this is a breaking change, but is see a few options:

* accept the breaking change and schedule it for version 3 of airline
* turn the signature of the CommandFactory to a default method which calls the old signature for instantiation and calls the context for the injection (requires Java 8)
* create a new interface with extends the CommandFactory, adds the new signature and check with instanceof in the ParserUtil
* keep the old signature and populate the context over ThreadLocal

I've also had to add a dependency to jsr305 in order to support the null injection of CommandGroupMetadata.