### PR TITLE
added channel implementation which allows other targets as System.out

### DIFF
--- a/airline-core/src/main/java/com/github/rvesse/airline/ChannelFactory.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/ChannelFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.rvesse.airline;
 
 import java.io.InputStream;

--- a/airline-core/src/main/java/com/github/rvesse/airline/ChannelFactory.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/ChannelFactory.java
@@ -1,0 +1,31 @@
+package com.github.rvesse.airline;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+
+/**
+ * Factory for various channels used by airline.
+ */
+public interface ChannelFactory {
+
+    /**
+     * Returns output channel.
+     *
+     * @return output channel
+     */
+    PrintStream createOutput();
+
+    /**
+     * Returns error channel.
+     *
+     * @return error channel
+     */
+    PrintStream createError();
+
+    /**
+     * Returns input channel.
+     *
+     * @return input channel
+     */
+    InputStream createInput();
+}

--- a/airline-core/src/main/java/com/github/rvesse/airline/Channels.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/Channels.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+/**
+ * Channels provides methods for the cli output, error and input channels. The implementation of the channels can be
+ * changed with an implementation of {@link ChannelFactory} which must be registered via {@link ServiceLoader}. The
+ * default implementation is {@link SystemChannelFactory}.
+ */
+public final class Channels {
+
+    private static ChannelFactory FACTORY;
+
+    static {
+        ServiceLoader<ChannelFactory> serviceLoader = ServiceLoader.load(ChannelFactory.class);
+        Iterator<ChannelFactory> iterator = serviceLoader.iterator();
+        if (iterator.hasNext()) {
+            FACTORY = iterator.next();
+        } else {
+            FACTORY = new SystemChannelFactory();
+        }
+    }
+
+    private Channels() {
+    }
+
+    /**
+     * Returns output channel.
+     *
+     * @return output channel
+     */
+    public static PrintStream output() {
+        return FACTORY.createOutput();
+    }
+
+    /**
+     * Returns error channel.
+     *
+     * @return error channel
+     */
+    public static PrintStream error() {
+        return FACTORY.createError();
+    }
+
+    /**
+     * Returns input channel.
+     *
+     * @return input channel
+     */
+    public static InputStream input() {
+        return FACTORY.createInput();
+    }
+
+
+}

--- a/airline-core/src/main/java/com/github/rvesse/airline/SystemChannelFactory.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/SystemChannelFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.rvesse.airline;
 
 import java.io.InputStream;

--- a/airline-core/src/main/java/com/github/rvesse/airline/SystemChannelFactory.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/SystemChannelFactory.java
@@ -1,0 +1,26 @@
+package com.github.rvesse.airline;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+
+/**
+ * Default implementation of {@link ChannelFactory} which uses {@code System.out}, {@code System.err} and
+ * {@code System.in} for the channels.
+ */
+public final class SystemChannelFactory implements ChannelFactory {
+
+    @Override
+    public PrintStream createOutput() {
+        return System.out;
+    }
+
+    @Override
+    public PrintStream createError() {
+        return System.err;
+    }
+
+    @Override
+    public InputStream createInput() {
+        return System.in;
+    }
+}

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/Help.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/Help.java
@@ -17,6 +17,7 @@ package com.github.rvesse.airline.help;
 
 import javax.inject.Inject;
 
+import com.github.rvesse.airline.Channels;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Predicate;
 
@@ -69,30 +70,30 @@ public class Help<T> implements Runnable, Callable<Void> {
 
     /**
      * Displays plain text format help for the given command to standard out
-     * 
+     *
      * @param command
      *            Command
      * @throws IOException
      */
     public static void help(CommandMetadata command) throws IOException {
-        help(command, System.out);
+        help(command, Channels.output());
     }
 
     /**
      * Displays plain text format help for the given command to standard out
-     * 
+     *
      * @param command
      *            Command
      * @throws IOException
      */
     public static void help(CommandMetadata command, boolean includeHidden) throws IOException {
-        help(command, includeHidden, System.out);
+        help(command, includeHidden, Channels.output());
     }
 
     /**
      * Displays plain text format help or the given command to the given output
      * stream
-     * 
+     *
      * @param command
      *            Command
      * @param out
@@ -106,7 +107,7 @@ public class Help<T> implements Runnable, Callable<Void> {
     /**
      * Displays plain text format help or the given command to the given output
      * stream
-     * 
+     *
      * @param command
      *            Command
      * @param out
@@ -119,7 +120,7 @@ public class Help<T> implements Runnable, Callable<Void> {
 
     /**
      * Displays plain text format program help to standard out
-     * 
+     *
      * @param global
      *            Program metadata
      * @param commandNames
@@ -127,12 +128,12 @@ public class Help<T> implements Runnable, Callable<Void> {
      * @throws IOException
      */
     public static <T> void help(GlobalMetadata<T> global, List<String> commandNames) throws IOException {
-        help(global, commandNames, false, System.out);
+        help(global, commandNames, false, Channels.output());
     }
 
     /**
      * Displays plain text format program help to standard out
-     * 
+     *
      * @param global
      *            Program metadata
      * @param commandNames
@@ -143,12 +144,12 @@ public class Help<T> implements Runnable, Callable<Void> {
      */
     public static <T> void help(GlobalMetadata<T> global, List<String> commandNames, boolean includeHidden)
             throws IOException {
-        help(global, commandNames, includeHidden, System.out);
+        help(global, commandNames, includeHidden, Channels.output());
     }
 
     /**
      * Displays plain text format program help to the given output stream
-     * 
+     *
      * @param global
      *            Program meta-data
      * @param commandNames
@@ -164,7 +165,7 @@ public class Help<T> implements Runnable, Callable<Void> {
 
     /**
      * Displays plain text format program help to the given output stream
-     * 
+     *
      * @param global
      *            Program meta-data
      * @param commandNames
@@ -193,8 +194,8 @@ public class Help<T> implements Runnable, Callable<Void> {
         Predicate<CommandGroupMetadata> findGroupPredicate;
         Predicate<CommandMetadata> findCommandPredicate;
         //@formatter:off
-        findGroupPredicate = global.getParserConfiguration().allowsAbbreviatedCommands() 
-                             ? new AbbreviatedGroupFinder(name, global.getCommandGroups()) 
+        findGroupPredicate = global.getParserConfiguration().allowsAbbreviatedCommands()
+                             ? new AbbreviatedGroupFinder(name, global.getCommandGroups())
                              : new GroupFinder(name);
         //@formatter:on
 
@@ -220,8 +221,8 @@ public class Help<T> implements Runnable, Callable<Void> {
                     commandOrSubGroupName = commandNames.get(i);
 
                     //@formatter:off
-                    findGroupPredicate = global.getParserConfiguration().allowsAbbreviatedCommands() 
-                                         ? new AbbreviatedGroupFinder(commandOrSubGroupName, group.getSubGroups()) 
+                    findGroupPredicate = global.getParserConfiguration().allowsAbbreviatedCommands()
+                                         ? new AbbreviatedGroupFinder(commandOrSubGroupName, group.getSubGroups())
                                          : new GroupFinder(commandOrSubGroupName);
                     //@formatter:on
                     CommandGroupMetadata subGroup = CollectionUtils.find(group.getSubGroups(), findGroupPredicate);
@@ -246,7 +247,7 @@ public class Help<T> implements Runnable, Callable<Void> {
                 commandOrSubGroupName = commandNames.get(i);
 
                 //@formatter:off
-                findCommandPredicate = global.getParserConfiguration().allowsAbbreviatedCommands() 
+                findCommandPredicate = global.getParserConfiguration().allowsAbbreviatedCommands()
                                        ? new AbbreviatedCommandFinder(commandOrSubGroupName, group.getCommands())
                                        : new CommandFinder(commandOrSubGroupName);
                 //@formatter:on
@@ -259,17 +260,17 @@ public class Help<T> implements Runnable, Callable<Void> {
 
                 // Didn't find an appropriate command
                 if (global.getParserConfiguration().allowsAbbreviatedCommands()) {
-                    System.out.println(
+                    Channels.output().println(
                             "Unknown command " + name + " " + commandOrSubGroupName + " or an ambiguous abbreviation");
                 } else {
-                    System.out.println("Unknown command " + name + " " + commandOrSubGroupName);
+                    Channels.output().println("Unknown command " + name + " " + commandOrSubGroupName);
                 }
             }
         }
 
         // A command in the default group?
         //@formatter:off
-        findCommandPredicate = global.getParserConfiguration().allowsAbbreviatedCommands() 
+        findCommandPredicate = global.getParserConfiguration().allowsAbbreviatedCommands()
                                ? new AbbreviatedCommandFinder(name, global.getDefaultGroupCommands())
                                : new CommandFinder(name);
         //@formatter:on
@@ -283,9 +284,9 @@ public class Help<T> implements Runnable, Callable<Void> {
 
         // Didn't find an appropriate group
         if (global.getParserConfiguration().allowsAbbreviatedCommands()) {
-            System.out.println("Unknown command " + name + " or an ambiguous abbreviation");
+            Channels.output().println("Unknown command " + name + " or an ambiguous abbreviation");
         } else {
-            System.out.println("Unknown command " + name);
+            Channels.output().println("Unknown command " + name);
         }
     }
 }

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/common/AbstractCommandGroupUsageGenerator.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/common/AbstractCommandGroupUsageGenerator.java
@@ -18,6 +18,7 @@ package com.github.rvesse.airline.help.common;
 import java.io.IOException;
 import java.util.Comparator;
 
+import com.github.rvesse.airline.Channels;
 import com.github.rvesse.airline.help.CommandGroupUsageGenerator;
 import com.github.rvesse.airline.help.UsageHelper;
 import com.github.rvesse.airline.help.sections.HelpHint;
@@ -45,6 +46,6 @@ public abstract class AbstractCommandGroupUsageGenerator<T> extends AbstractUsag
 
     @Override
     public void usage(GlobalMetadata<T> global, CommandGroupMetadata[] groups) throws IOException {
-        usage(global, groups, System.out);
+        usage(global, groups, Channels.output());
     }
 }

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/common/AbstractCommandUsageGenerator.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/common/AbstractCommandUsageGenerator.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map.Entry;
 
+import com.github.rvesse.airline.Channels;
 import com.github.rvesse.airline.help.CommandUsageGenerator;
 import com.github.rvesse.airline.help.UsageHelper;
 import com.github.rvesse.airline.help.sections.HelpHint;
@@ -34,7 +35,7 @@ import com.github.rvesse.airline.utils.comparators.HelpSectionComparator;
 
 /**
  * Abstract command usage generator
- * 
+ *
  */
 public abstract class AbstractCommandUsageGenerator extends AbstractUsageGenerator implements CommandUsageGenerator {
 
@@ -68,7 +69,7 @@ public abstract class AbstractCommandUsageGenerator extends AbstractUsageGenerat
     @Override
     public <T> void usage(String programName, String[] groupNames, String commandName, CommandMetadata command,
             ParserMetadata<T> parserConfig) throws IOException {
-        usage(programName, groupNames, commandName, command, parserConfig, System.out);
+        usage(programName, groupNames, commandName, command, parserConfig, Channels.output());
     }
 
     /**
@@ -79,7 +80,7 @@ public abstract class AbstractCommandUsageGenerator extends AbstractUsageGenerat
     @Deprecated
     public void usage(String programName, String[] groupNames, String commandName, CommandMetadata command)
             throws IOException {
-        usage(programName, groupNames, commandName, command, null, System.out);
+        usage(programName, groupNames, commandName, command, null, Channels.output());
     }
 
     /**
@@ -96,7 +97,7 @@ public abstract class AbstractCommandUsageGenerator extends AbstractUsageGenerat
     /**
      * Sorts the exit codes assuming a non-null comparator was provided at
      * instantiation time
-     * 
+     *
      * @param exitCodes
      *            Exit codes
      * @return Sorted exit codes
@@ -111,7 +112,7 @@ public abstract class AbstractCommandUsageGenerator extends AbstractUsageGenerat
 
     /**
      * Finds the help sections
-     * 
+     *
      * @param command
      *            Command meta-data
      * @param preSections

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/common/AbstractGlobalUsageGenerator.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/common/AbstractGlobalUsageGenerator.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import com.github.rvesse.airline.Channels;
 import com.github.rvesse.airline.help.GlobalUsageGenerator;
 import com.github.rvesse.airline.help.UsageHelper;
 import com.github.rvesse.airline.help.sections.HelpHint;
@@ -56,13 +57,13 @@ public abstract class AbstractGlobalUsageGenerator<T> extends AbstractUsageGener
 
     @Override
     public void usage(GlobalMetadata<T> global) throws IOException {
-        usage(global, System.out);
+        usage(global, Channels.output());
     }
 
     /**
      * Sorts the command groups assumign a non-null comparator was provided at
      * instantiation time
-     * 
+     *
      * @param groups
      *            Command groups
      * @return Sorted command groups

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/SuggestCommand.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/SuggestCommand.java
@@ -15,6 +15,7 @@
  */
 package com.github.rvesse.airline.help.suggester;
 
+import com.github.rvesse.airline.Channels;
 import com.github.rvesse.airline.Context;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
@@ -90,7 +91,7 @@ public class SuggestCommand<T> implements Runnable, Callable<Void> {
 
     @Override
     public void run() {
-        System.out.println(StringUtils.join(generateSuggestions(), '\n'));
+        Channels.output().println(StringUtils.join(generateSuggestions(), '\n'));
     }
 
     @Override

--- a/airline-core/src/test/java/com/github/rvesse/airline/ChannelsTest.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/ChannelsTest.java
@@ -1,0 +1,54 @@
+package com.github.rvesse.airline;
+
+import org.testng.annotations.Test;
+
+import java.io.*;
+
+import static org.testng.Assert.assertEquals;
+
+public class ChannelsTest {
+
+    @Test
+    public void testOutput() {
+        PrintStream oldOutput = System.out;
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            System.setOut(new PrintStream(output));
+
+            Channels.output().append("some output");
+            assertEquals(output.toString(), "some output");
+        } finally {
+          System.setOut(oldOutput);
+        }
+    }
+
+    @Test
+    public void testError() {
+        PrintStream oldError = System.err;
+        try {
+            ByteArrayOutputStream error = new ByteArrayOutputStream();
+            System.setErr(new PrintStream(error));
+
+            Channels.error().append("some error");
+            assertEquals(error.toString(), "some error");
+        } finally {
+            System.setErr(oldError);
+        }
+    }
+
+    @Test
+    public void testInput() throws IOException {
+        InputStream oldInput = System.in;
+        try {
+            byte[] inputData = "some input".getBytes();
+            ByteArrayInputStream input = new ByteArrayInputStream(inputData);
+            System.setIn(input);
+
+            byte[] readData = new byte[inputData.length];
+            Channels.input().read(readData);
+            assertEquals(new String(readData), "some input");
+        } finally {
+            System.setIn(oldInput);
+        }
+    }
+}

--- a/airline-core/src/test/java/com/github/rvesse/airline/ChannelsTest.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/ChannelsTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.rvesse.airline;
 
 import org.testng.annotations.Test;


### PR DESCRIPTION
I'm planning an client server application which does the command application on the server side. The client sends the command line arguments to the server and the server parses the argument and executes the command.

The problem is that some of the internal classes uses System.out, which does not work in such an environment.

I've created a Channels class which replaces all System.out calls in airline. The Channels class is able to get an implementation of a ChannelFactory via java 6 ServiceLoader mechanism, the default implementation of the ChannelFactory uses System.out.