### PR TITLE
Enable JDK 9+ builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
   - openjdk8
   - openjdk9
   - openjdk10
-  - openjdk11
+#  - openjdk11 # Not currently supported by Jacoco plugin
 env:
   - MAVEN_OPTS="-Dhttps.protocol=TLSv1.2"
 script: mvn install -Prelease -Dgpg.skip=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ install: true
 jdk: 
   - openjdk7
   - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
 env:
   - MAVEN_OPTS="-Dhttps.protocol=TLSv1.2"
 script: mvn install -Prelease -Dgpg.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -479,7 +479,9 @@
               <encoding>UTF-8</encoding>
               <charset>UTF-8</charset>
               <docencoding>UTF-8</docencoding>
-              <additionalparam>-Xdoclint:none</additionalparam>
+              <additionalOptions>
+                <option>-Xdoclint:none</option>
+              </additionalOptions>
             </configuration>
           </plugin>
         </plugins>
@@ -512,7 +514,9 @@
               <encoding>UTF-8</encoding>
               <charset>UTF-8</charset>
               <docencoding>UTF-8</docencoding>
-              <additionalparam>-Xdoclint:none</additionalparam>
+              <additionalOptions>
+                <option>-Xdoclint:none</option>
+              </additionalOptions>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <plugin.release>2.5.3</plugin.release>
     <plugin.gpg>1.6</plugin.gpg>
     <plugin.shade>3.1.1</plugin.shade>
+    <plugin.surefire>2.22.0</plugin.surefire>
 
     <!-- Dependency Versions -->
     <dependency.javax-inject>1</dependency.javax-inject>
@@ -128,6 +129,13 @@
           <target>${jdk.target}</target>
           <encoding>UTF-8</encoding>
         </configuration>
+      </plugin>
+      
+      <!-- Surefire Plugin -->
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${plugin.surefire}</version>
       </plugin>
 
       <!-- JAR Plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,17 +57,17 @@
     <plugin.antrun>1.8</plugin.antrun>
     <plugin.assembly>3.1.0</plugin.assembly>
     <plugin.buildnumber>1.4</plugin.buildnumber>
-    <plugin.compiler>3.2</plugin.compiler>
+    <plugin.compiler>3.7.0</plugin.compiler>
     <plugin.coveralls>4.3.0</plugin.coveralls>
-    <plugin.enforcer>1.3.1</plugin.enforcer>
+    <plugin.enforcer>1.4.1</plugin.enforcer>
     <plugin.license>2.11</plugin.license>
     <plugin.jacoco>0.8.1</plugin.jacoco>
-    <plugin.jar>2.5</plugin.jar>
-    <plugin.source>2.4</plugin.source>
-    <plugin.javadoc>2.10.1</plugin.javadoc>
-    <plugin.release>2.5.1</plugin.release>
-    <plugin.gpg>1.5</plugin.gpg>
-    <plugin.shade>2.3</plugin.shade>
+    <plugin.jar>3.1.0</plugin.jar>
+    <plugin.source>3.0.1</plugin.source>
+    <plugin.javadoc>3.0.1</plugin.javadoc>
+    <plugin.release>2.5.3</plugin.release>
+    <plugin.gpg>1.6</plugin.gpg>
+    <plugin.shade>3.1.1</plugin.shade>
 
     <!-- Dependency Versions -->
     <dependency.javax-inject>1</dependency.javax-inject>
@@ -457,6 +457,39 @@
       <id>javadoc-jdk8</id>
       <activation>
         <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <!-- Javadoc Plugin -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${plugin.javadoc}</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <javadocVersion>${jdk.target}</javadocVersion>
+              <quiet>true</quiet>
+              <encoding>UTF-8</encoding>
+              <charset>UTF-8</charset>
+              <docencoding>UTF-8</docencoding>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    
+    <profile>
+      <id>javadoc-jdk10-plus</id>
+      <activation>
+        <jdk>10</jdk>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
Updates the build spec to update plugins and configuration to make the build work on JDK 9 and above, note we still target our output to JDK 7 for backwards compatibility.

Travis CI integration is updated to build on JDK 7 through 11