### PR TITLE
Support Java9 modules while still Java7+ compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ jdk:
 #  - openjdk11 # Not currently supported by Jacoco plugin
 env:
   - MAVEN_OPTS="-Dhttps.protocol=TLSv1.2"
-script: mvn install -Prelease -Dgpg.skip=true
+script: mvn install -Prelease -Dgpg.skip=true -Djdk.enforced=1.7
 after_success: mvn package -Pcoveralls

--- a/airline-core/pom.xml
+++ b/airline-core/pom.xml
@@ -17,6 +17,7 @@
   <properties>
     <license.header.path>${project.parent.basedir}</license.header.path>
     <coveralls.skip>true</coveralls.skip>
+    <moditect.moduleName>com.github.rvesse.airline</moditect.moduleName>
   </properties>
 
   <dependencies>

--- a/airline-core/src/main/moditect/module-info.java
+++ b/airline-core/src/main/moditect/module-info.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module com.github.rvesse.airline
+{
+  requires com.github.rvesse.airline.io;
+  requires org.apache.commons.collections4;
+  requires javax.inject;
+
+  exports com.github.rvesse.airline;
+  exports com.github.rvesse.airline.annotations;
+  exports com.github.rvesse.airline.annotations.help;
+  exports com.github.rvesse.airline.annotations.restrictions;
+  exports com.github.rvesse.airline.annotations.restrictions.global;
+  exports com.github.rvesse.airline.annotations.restrictions.ranges;
+  exports com.github.rvesse.airline.builder;
+  exports com.github.rvesse.airline.help;
+  exports com.github.rvesse.airline.help.cli;
+  exports com.github.rvesse.airline.help.common;
+  exports com.github.rvesse.airline.help.sections;
+  exports com.github.rvesse.airline.help.sections.common;
+  exports com.github.rvesse.airline.help.sections.factories;
+  exports com.github.rvesse.airline.help.suggester;
+  exports com.github.rvesse.airline.model;
+  exports com.github.rvesse.airline.parser;
+  exports com.github.rvesse.airline.parser.aliases;
+  exports com.github.rvesse.airline.parser.command;
+  exports com.github.rvesse.airline.parser.errors;
+  exports com.github.rvesse.airline.parser.errors.handlers;
+  exports com.github.rvesse.airline.parser.options;
+  exports com.github.rvesse.airline.parser.resources;
+  exports com.github.rvesse.airline.parser.suggester;
+  exports com.github.rvesse.airline.restrictions;
+  exports com.github.rvesse.airline.restrictions.common;
+  exports com.github.rvesse.airline.restrictions.factories;
+  exports com.github.rvesse.airline.restrictions.global;
+  exports com.github.rvesse.airline.restrictions.options;
+  exports com.github.rvesse.airline.types;
+  exports com.github.rvesse.airline.utils;
+}

--- a/airline-core/src/main/moditect/module-info.java
+++ b/airline-core/src/main/moditect/module-info.java
@@ -20,38 +20,6 @@ module com.github.rvesse.airline
   requires org.apache.commons.collections4;
   requires javax.inject;
 
-  uses com.github.rvesse.airline.ChannelFactory;
-  uses com.github.rvesse.airline.help.sections.factories.HelpSectionFactory;
-  uses com.github.rvesse.airline.restrictions.factories.ArgumentsRestrictionFactory;
-  uses com.github.rvesse.airline.restrictions.factories.GlobalRestrictionFactory;
-  uses com.github.rvesse.airline.restrictions.factories.OptionRestrictionFactory;
-
-  provides com.github.rvesse.airline.help.sections.factories.HelpSectionFactory with
-      com.github.rvesse.airline.help.sections.factories.CommonSectionsFactory;
-
-  provides com.github.rvesse.airline.restrictions.factories.ArgumentsRestrictionFactory with
-      com.github.rvesse.airline.restrictions.factories.AllowedValuesRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.OccurrencesRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.PathRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.PortRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.RangeRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.SimpleRestrictionsFactory,
-      com.github.rvesse.airline.restrictions.factories.StringRestrictionFactory;
-
-  provides com.github.rvesse.airline.restrictions.factories.GlobalRestrictionFactory with
-      com.github.rvesse.airline.restrictions.factories.StandardGlobalRestrictionsFactory;
-
-  provides com.github.rvesse.airline.restrictions.factories.OptionRestrictionFactory with
-      com.github.rvesse.airline.restrictions.factories.AllowedValuesRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.OccurrencesRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.PathRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.PortRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.RangeRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.RequiredOnlyIfRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.RequireFromRestrictionFactory,
-      com.github.rvesse.airline.restrictions.factories.SimpleRestrictionsFactory,
-      com.github.rvesse.airline.restrictions.factories.StringRestrictionFactory;
-
   exports com.github.rvesse.airline;
   exports com.github.rvesse.airline.annotations;
   exports com.github.rvesse.airline.annotations.help;
@@ -81,5 +49,45 @@ module com.github.rvesse.airline
   exports com.github.rvesse.airline.restrictions.global;
   exports com.github.rvesse.airline.restrictions.options;
   exports com.github.rvesse.airline.types;
+  exports com.github.rvesse.airline.types.numerics;
+  exports com.github.rvesse.airline.types.numerics.abbreviated;
+  exports com.github.rvesse.airline.types.numerics.bases;
   exports com.github.rvesse.airline.utils;
+  exports com.github.rvesse.airline.utils.comparators;
+  exports com.github.rvesse.airline.utils.predicates;
+  exports com.github.rvesse.airline.utils.predicates.parser;
+  exports com.github.rvesse.airline.utils.predicates.restrictions;
+
+  provides com.github.rvesse.airline.help.sections.factories.HelpSectionFactory with
+      com.github.rvesse.airline.help.sections.factories.CommonSectionsFactory;
+
+  provides com.github.rvesse.airline.restrictions.factories.ArgumentsRestrictionFactory with
+      com.github.rvesse.airline.restrictions.factories.AllowedValuesRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.OccurrencesRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.PathRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.PortRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.RangeRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.SimpleRestrictionsFactory,
+      com.github.rvesse.airline.restrictions.factories.StringRestrictionFactory;
+
+  provides com.github.rvesse.airline.restrictions.factories.GlobalRestrictionFactory with
+      com.github.rvesse.airline.restrictions.factories.StandardGlobalRestrictionsFactory;
+
+  provides com.github.rvesse.airline.restrictions.factories.OptionRestrictionFactory with
+      com.github.rvesse.airline.restrictions.factories.AllowedValuesRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.OccurrencesRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.PathRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.PortRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.RangeRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.RequiredOnlyIfRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.RequireFromRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.SimpleRestrictionsFactory,
+      com.github.rvesse.airline.restrictions.factories.StringRestrictionFactory;
+
+  uses com.github.rvesse.airline.ChannelFactory;
+  uses com.github.rvesse.airline.help.sections.factories.HelpSectionFactory;
+  uses com.github.rvesse.airline.restrictions.factories.ArgumentsRestrictionFactory;
+  uses com.github.rvesse.airline.restrictions.factories.GlobalRestrictionFactory;
+  uses com.github.rvesse.airline.restrictions.factories.OptionRestrictionFactory;
+
 }

--- a/airline-core/src/main/moditect/module-info.java
+++ b/airline-core/src/main/moditect/module-info.java
@@ -16,6 +16,7 @@
 module com.github.rvesse.airline
 {
   requires com.github.rvesse.airline.io;
+  requires org.apache.commons.lang3;
   requires org.apache.commons.collections4;
   requires javax.inject;
 
@@ -24,6 +25,32 @@ module com.github.rvesse.airline
   uses com.github.rvesse.airline.restrictions.factories.ArgumentsRestrictionFactory;
   uses com.github.rvesse.airline.restrictions.factories.GlobalRestrictionFactory;
   uses com.github.rvesse.airline.restrictions.factories.OptionRestrictionFactory;
+
+  provides com.github.rvesse.airline.help.sections.factories.HelpSectionFactory with
+      com.github.rvesse.airline.help.sections.factories.CommonSectionsFactory;
+
+  provides com.github.rvesse.airline.restrictions.factories.ArgumentsRestrictionFactory with
+      com.github.rvesse.airline.restrictions.factories.AllowedValuesRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.OccurrencesRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.PathRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.PortRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.RangeRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.SimpleRestrictionsFactory,
+      com.github.rvesse.airline.restrictions.factories.StringRestrictionFactory;
+
+  provides com.github.rvesse.airline.restrictions.factories.GlobalRestrictionFactory with
+      com.github.rvesse.airline.restrictions.factories.StandardGlobalRestrictionsFactory;
+
+  provides com.github.rvesse.airline.restrictions.factories.OptionRestrictionFactory with
+      com.github.rvesse.airline.restrictions.factories.AllowedValuesRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.OccurrencesRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.PathRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.PortRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.RangeRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.RequiredOnlyIfRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.RequireFromRestrictionFactory,
+      com.github.rvesse.airline.restrictions.factories.SimpleRestrictionsFactory,
+      com.github.rvesse.airline.restrictions.factories.StringRestrictionFactory;
 
   exports com.github.rvesse.airline;
   exports com.github.rvesse.airline.annotations;

--- a/airline-core/src/main/moditect/module-info.java
+++ b/airline-core/src/main/moditect/module-info.java
@@ -19,6 +19,12 @@ module com.github.rvesse.airline
   requires org.apache.commons.collections4;
   requires javax.inject;
 
+  uses com.github.rvesse.airline.ChannelFactory;
+  uses com.github.rvesse.airline.help.sections.factories.HelpSectionFactory;
+  uses com.github.rvesse.airline.restrictions.factories.ArgumentsRestrictionFactory;
+  uses com.github.rvesse.airline.restrictions.factories.GlobalRestrictionFactory;
+  uses com.github.rvesse.airline.restrictions.factories.OptionRestrictionFactory;
+
   exports com.github.rvesse.airline;
   exports com.github.rvesse.airline.annotations;
   exports com.github.rvesse.airline.annotations.help;

--- a/airline-io/pom.xml
+++ b/airline-io/pom.xml
@@ -12,6 +12,7 @@
   <properties>
     <license.header.path>${project.parent.basedir}</license.header.path>
     <coveralls.skip>true</coveralls.skip>
+    <moditect.moduleName>com.github.rvesse.airline.io</moditect.moduleName>
   </properties>
 
   <dependencies>

--- a/airline-io/src/main/moditect/module-info.java
+++ b/airline-io/src/main/moditect/module-info.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module com.github.rvesse.airline.io
+{
+  requires org.apache.commons.lang3;
+
+  exports com.github.rvesse.airline.io;
+  exports com.github.rvesse.airline.io.colors;
+  exports com.github.rvesse.airline.io.colors.sources;
+  exports com.github.rvesse.airline.io.decorations;
+  exports com.github.rvesse.airline.io.decorations.sources;
+  exports com.github.rvesse.airline.io.output;
+  exports com.github.rvesse.airline.io.printers;
+  exports com.github.rvesse.airline.io.writers;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -563,6 +563,7 @@
                   <goal>add-module-info</goal>
                 </goals>
                 <configuration>
+                  <jvmVersion>9</jvmVersion>
                   <overwriteExistingFiles>true</overwriteExistingFiles>
                   <module>
                     <moduleInfoFile>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <plugin.gpg>1.6</plugin.gpg>
     <plugin.shade>3.1.1</plugin.shade>
     <plugin.surefire>2.22.0</plugin.surefire>
+    <plugin.moditect>1.0.0.Beta2</plugin.moditect>
 
     <!-- Dependency Versions -->
     <dependency.javax-inject>1</dependency.javax-inject>
@@ -531,6 +532,43 @@
                 <option>-Xdoclint:none</option>
               </additionalOptions>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>moditect-jdk8-plus</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+        <file>
+          <exists>${basedir}/src/main/moditect/module-info.java</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.moditect</groupId>
+            <artifactId>moditect-maven-plugin</artifactId>
+            <version>${plugin.moditect}</version>
+            <executions>
+              <execution>
+                <id>add-module-infos</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>add-module-info</goal>
+                </goals>
+                <configuration>
+                  <jvmVersion>9</jvmVersion>
+                  <overwriteExistingFiles>true</overwriteExistingFiles>
+                  <module>
+                    <moduleInfoFile>
+                      ${basedir}/src/main/moditect/module-info.java
+                    </moduleInfoFile>
+                  </module>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -578,6 +578,35 @@
     </profile>
 
     <profile>
+      <id>automatic-module-name</id>
+      <activation>
+        <property>
+          <name>moditect.skip</name>
+          <value>true</value>
+        </property>
+        <file>
+          <exists>${basedir}/src/main/moditect/module-info.java</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>${plugin.jar}</version>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Automatic-Module-Name>${moditect.moduleName}</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>generate-module-info</id>
       <properties>
         <jdk.enforced>9</jdk.enforced>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 
   <properties>
     <jdk.target>1.7</jdk.target>
+    <jdk.enforced>1.7</jdk.enforced>
     <license.header.path>${project.basedir}</license.header.path>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
 
@@ -163,7 +164,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>${jdk.target}</version>
+                  <version>${jdk.enforced}</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -387,6 +388,9 @@
         <module>airline-maven-plugin</module>
         <module>docs</module>
       </modules>
+      <properties>
+        <jdk.enforced>1.8</jdk.enforced>
+      </properties>
       <build>
         <plugins>
           <!-- Release Plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -563,13 +563,56 @@
                   <goal>add-module-info</goal>
                 </goals>
                 <configuration>
-                  <jvmVersion>9</jvmVersion>
                   <overwriteExistingFiles>true</overwriteExistingFiles>
                   <module>
                     <moduleInfoFile>
                       ${basedir}/src/main/moditect/module-info.java
                     </moduleInfoFile>
                   </module>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>generate-module-info</id>
+      <properties>
+        <jdk.enforced>9</jdk.enforced>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.moditect</groupId>
+            <artifactId>moditect-maven-plugin</artifactId>
+            <version>${plugin.moditect}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>generate-module-info</goal>
+                </goals>
+                <configuration>
+                  <modules>
+                    <module>
+                      <artifact>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>${project.artifactId}</artifactId>
+                        <version>${project.version}</version>
+                      </artifact>
+                      <moduleInfo>
+                        <name>${moditect.moduleName}</name>
+                        <exports>
+                            *;
+                        </exports>
+                        <requires>
+                            *;
+                        </requires>
+                        <addServiceUses>true</addServiceUses>
+                      </moduleInfo>
+                    </module>
+                  </modules>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Uses `moditect` to generate `module-info.class` without requiring Java9 as minimum source version.
Successful local builds with Java7, Java8, Java9, Java10.

Note: `moditect` requires Java8, so while Java7 build is successful, no `module-info.class` is included in the final JAR when built with Java7 toolchain.

Recommend performing releases with Java8 to include `module-info.class`.

Now enforcing Java8 toolchain in `release` profile while still targeting `1.7` class format for runtime compatibility.