### PR TITLE
Use automatic module dependency for javax.inject package

### DIFF
--- a/airline-core/pom.xml
+++ b/airline-core/pom.xml
@@ -28,8 +28,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
     </dependency>
 
     <dependency>

--- a/airline-core/src/main/moditect/module-info.java
+++ b/airline-core/src/main/moditect/module-info.java
@@ -18,7 +18,7 @@ module com.github.rvesse.airline
   requires com.github.rvesse.airline.io;
   requires org.apache.commons.lang3;
   requires org.apache.commons.collections4;
-  requires javax.inject;
+  requires java.inject;
 
   exports com.github.rvesse.airline;
   exports com.github.rvesse.airline.annotations;

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <plugin.moditect>1.0.0.Beta2</plugin.moditect>
 
     <!-- Dependency Versions -->
-    <dependency.javax-inject>1</dependency.javax-inject>
+    <dependency.javax-inject>1.0.3</dependency.javax-inject>
     <dependency.junit>4.12</dependency.junit>
     <dependency.testng>6.8.8</dependency.testng>
     <dependency.commons-lang3>3.7</dependency.commons-lang3>
@@ -88,8 +88,8 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>javax.inject</groupId>
-        <artifactId>javax.inject</artifactId>
+        <groupId>jakarta.inject</groupId>
+        <artifactId>jakarta.inject-api</artifactId>
         <version>${dependency.javax-inject}</version>
       </dependency>
 


### PR DESCRIPTION
When building modular components based on `airline`, the following message is displayed during compilation.
```
[INFO] --- maven-compiler-plugin:3.8.0:compile (default-compile) @ ry ---
[WARNING] ********************************************************************************************************************
[WARNING] * Required filename-based automodules detected. Please don't publish this project to a public artifact repository! *
[WARNING] ********************************************************************************************************************
```

This is caused by the `javax.inject` dependency which is missing the `Automatic-Module-Name` entry from the JAR manifest, so the module name is derived from the JAR filename instead. Although the JAR filename is not expected to change for the `javax.inject` dependency, a JAR filename is not considered sufficiently stable to derive a module name in the general case, triggering the compilation warning above.

As explained by the [Transition from Java EE to Jakarta EE](https://blogs.oracle.com/javamagazine/transition-from-java-ee-to-jakarta-ee) blog post, the `javax` namespace is migrating to `jakarta` going forward, so this is a good first step towards fully modular `jakarta` based dependencies for `javax.inject`.

This pull request addresses the issue by changing the dependency to use an alternative dependency that delivers an automatic module for `javax.inject` package instead.