### PR TITLE
Rename Path annotations to avoid naming conflicts (#107)

### DIFF
--- a/Migrating.md
+++ b/Migrating.md
@@ -1,6 +1,6 @@
 # Migration to Airline 3 from Airline 2.x
 
-TODO - Migration information will be added as breaking API changes are made
+Airline 3.x is a major upgrade to Airline that takes the oppurtunity of a major version bump to make various breaking changes that were necessary to enable new features and address long term pain points for users.
 
 ## `@Path`/`@File`/`@Directory` annotations
 
@@ -9,6 +9,8 @@ These annotations were renamed to add an `Is` prefix to avoid naming collisions 
 - `@Path` is now `@IsPath`
 - `@File` is now `@IsFile`
 - `@Directory` is now `@IsDirectory`
+
+---
 
 # Migration to Airline 2.2 from Airline 2.1
 

--- a/Migrating.md
+++ b/Migrating.md
@@ -2,6 +2,14 @@
 
 TODO - Migration information will be added as breaking API changes are made
 
+## `@Path`/`@File`/`@Directory` annotations
+
+These annotations were renamed to add an `Is` prefix to avoid naming collisions with common Java classes:
+
+- `@Path` is now `@IsPath`
+- `@File` is now `@IsFile`
+- `@Directory` is now `@IsDirectory`
+
 # Migration to Airline 2.2 from Airline 2.1
 
 Airline 2.2 has some minor breaking changes versus Airline 2.1

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/IsDirectory.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/IsDirectory.java
@@ -22,45 +22,38 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation that marks that an options value must be a valid path to a
- * file/directory
+ * directory
  *
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ FIELD })
-public @interface Path {
+public @interface IsDirectory {
 
     /**
-     * Gets/Sets whether the given file must exist
+     * Gets/Sets whether the given directory must exist
      * 
      * @return True if it must exist, false otherwise
      */
     public boolean mustExist() default false;
 
     /**
-     * Gets/Sets whether the given file must be writable
+     * Gets/Sets whether the given directory must be writable
      * 
      * @return True if must be writable, false otherwise
      */
     public boolean writable() default true;
 
     /**
-     * Gets/Sets whether the given file must be readable
+     * Gets/Sets whether the given directory must be readable
      * 
      * @return True if must be readable, false otherwise
      */
     public boolean readable() default true;
 
     /**
-     * Gets/Sets whether the given file must be executable
+     * Gets/Sets whether the given directory must be executable
      * 
      * @return True if must be executable, false otherwise
      */
     public boolean executable() default false;
-
-    /**
-     * Gets/Sets the kind of file that is expected
-     * 
-     * @return Expected file kind
-     */
-    public PathKind kind() default PathKind.ANY;
 }

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/IsFile.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/IsFile.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ FIELD })
-public @interface File {
+public @interface IsFile {
 
     /**
      * Gets/Sets whether the given file must exist

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/IsPath.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/IsPath.java
@@ -22,38 +22,45 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation that marks that an options value must be a valid path to a
- * directory
+ * file/directory
  *
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ FIELD })
-public @interface Directory {
+public @interface IsPath {
 
     /**
-     * Gets/Sets whether the given directory must exist
+     * Gets/Sets whether the given file must exist
      * 
      * @return True if it must exist, false otherwise
      */
     public boolean mustExist() default false;
 
     /**
-     * Gets/Sets whether the given directory must be writable
+     * Gets/Sets whether the given file must be writable
      * 
      * @return True if must be writable, false otherwise
      */
     public boolean writable() default true;
 
     /**
-     * Gets/Sets whether the given directory must be readable
+     * Gets/Sets whether the given file must be readable
      * 
      * @return True if must be readable, false otherwise
      */
     public boolean readable() default true;
 
     /**
-     * Gets/Sets whether the given directory must be executable
+     * Gets/Sets whether the given file must be executable
      * 
      * @return True if must be executable, false otherwise
      */
     public boolean executable() default false;
+
+    /**
+     * Gets/Sets the kind of file that is expected
+     * 
+     * @return Expected file kind
+     */
+    public PathKind kind() default PathKind.ANY;
 }

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/factories/PathRestrictionFactory.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/factories/PathRestrictionFactory.java
@@ -19,9 +19,9 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.github.rvesse.airline.annotations.restrictions.Directory;
-import com.github.rvesse.airline.annotations.restrictions.File;
-import com.github.rvesse.airline.annotations.restrictions.Path;
+import com.github.rvesse.airline.annotations.restrictions.IsDirectory;
+import com.github.rvesse.airline.annotations.restrictions.IsFile;
+import com.github.rvesse.airline.annotations.restrictions.IsPath;
 import com.github.rvesse.airline.annotations.restrictions.PathKind;
 import com.github.rvesse.airline.restrictions.ArgumentsRestriction;
 import com.github.rvesse.airline.restrictions.OptionRestriction;
@@ -30,16 +30,16 @@ import com.github.rvesse.airline.restrictions.common.PathRestriction;
 public class PathRestrictionFactory implements OptionRestrictionFactory, ArgumentsRestrictionFactory {
 
     protected final PathRestriction createCommon(Annotation annotation) {
-        if (annotation instanceof Path) {
-            Path path = (Path) annotation;
+        if (annotation instanceof IsPath) {
+            IsPath path = (IsPath) annotation;
             return new PathRestriction(path.mustExist(), path.readable(), path.writable(), path.executable(),
                     path.kind());
-        } else if (annotation instanceof File) {
-            File path = (File) annotation;
+        } else if (annotation instanceof IsFile) {
+            IsFile path = (IsFile) annotation;
             return new PathRestriction(path.mustExist(), path.readable(), path.writable(), path.executable(),
                     PathKind.FILE);
-        } else if (annotation instanceof Directory) {
-            Directory path = (Directory) annotation;
+        } else if (annotation instanceof IsDirectory) {
+            IsDirectory path = (IsDirectory) annotation;
             return new PathRestriction(path.mustExist(), path.readable(), path.writable(), path.executable(),
                     PathKind.DIRECTORY);
         }
@@ -58,9 +58,9 @@ public class PathRestrictionFactory implements OptionRestrictionFactory, Argumen
     
     protected List<Class<? extends Annotation>> supportedAnnotations() {
         ArrayList<Class<? extends Annotation>> supported = new ArrayList<>();
-        supported.add(Path.class);
-        supported.add(File.class);
-        supported.add(Directory.class);
+        supported.add(IsPath.class);
+        supported.add(IsFile.class);
+        supported.add(IsDirectory.class);
         return supported;
     }
 

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Paths.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Paths.java
@@ -18,38 +18,38 @@ package com.github.rvesse.airline.restrictions;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.PathKind;
-import com.github.rvesse.airline.annotations.restrictions.Directory;
-import com.github.rvesse.airline.annotations.restrictions.File;
-import com.github.rvesse.airline.annotations.restrictions.Path;
+import com.github.rvesse.airline.annotations.restrictions.IsDirectory;
+import com.github.rvesse.airline.annotations.restrictions.IsFile;
+import com.github.rvesse.airline.annotations.restrictions.IsPath;
 
 @Command(name = "paths")
 public class Paths {
 
     @Option(name = "--path", arity = 1)
-    @Path(mustExist = true)
+    @IsPath(mustExist = true)
     public String pathMustExist;
     
     @Option(name = "--file", arity = 1)
-    @File(mustExist = true)
+    @IsFile(mustExist = true)
     public String fileMustExit;
     
     @Option(name = "--directory", arity = 1)
-    @Directory(mustExist = true)
+    @IsDirectory(mustExist = true)
     public String dirMustExist;
     
     @Option(name = "--readable", arity = 1)
-    @Path(mustExist = false, readable = true, writable = false, executable = false)
+    @IsPath(mustExist = false, readable = true, writable = false, executable = false)
     public String readable;
     
     @Option(name = "--writable", arity = 1)
-    @Path(mustExist = false, writable = true, readable = false, executable = false)
+    @IsPath(mustExist = false, writable = true, readable = false, executable = false)
     public String writable;
     
     @Option(name = "--executable", arity = 1)
-    @Path(mustExist = false, executable = true, readable = false, writable = false)
+    @IsPath(mustExist = false, executable = true, readable = false, writable = false)
     public String executable;
     
     @Option(name = "--any", arity = 1)
-    @Path(mustExist = false, readable = false, writable = false, executable = false, kind = PathKind.ANY)
+    @IsPath(mustExist = false, readable = false, writable = false, executable = false, kind = PathKind.ANY)
     public String anyPath;
 }

--- a/docs/_includes/req-migration.md
+++ b/docs/_includes/req-migration.md
@@ -1,0 +1,4 @@
+<p markdown="1" class="message">
+    <i class="fa fa-exclamation-triangle fa-pull-left"></i> This feature requires existing user code to migrate when upgrading from {{ include.old-version }} to {{ include.version }}
+    <span>{{ include.message }}</span>
+ </p>

--- a/docs/_includes/req-migration.md
+++ b/docs/_includes/req-migration.md
@@ -1,4 +1,5 @@
 <p markdown="1" class="message">
     <i class="fa fa-exclamation-triangle fa-pull-left"></i> This feature requires existing user code to migrate when upgrading from {{ include.old-version }} to {{ include.version }}
-    <span>{{ include.message }}</span>
+    <br />
+    {{ include.message }}
  </p>

--- a/docs/_includes/restrictions.md
+++ b/docs/_includes/restrictions.md
@@ -25,7 +25,7 @@ The following annotations are used to specify restrictions on the values for opt
 - The [`@MinLength`]({{ include.path }}min-length.html) annotation specifies the minimum length of the value that may be given
 - The [`@NotBlank`]({{ include.path }}not-blank.html) annotation specifies that a value may not consist entirely of white space
 - The [`@NotEmpty`]({{ include.path }}not-empty.html) annotation specifies that the value may not be an empty string
-- The [`@Path`]({{ include.path }}path.html) annotation specifies restrictions on values that refer to files and/or directories
+- The [`@IsPath`]({{ include.path }}path.html) annotation specifies restrictions on values that refer to files and/or directories
 - The [`@Pattern`]({{ include.path }}pattern.html) annotation specifies that a value must match a regular expression
 - The [`@Port`]({{ include.path }}port.html) annotation specifies restrictions on values that represent port numbers
 

--- a/docs/guide/annotations/path.md
+++ b/docs/guide/annotations/path.md
@@ -2,7 +2,7 @@
 layout: page
 title: IsPath, IsFile and IsDirectory Annotations
 ---
-{% include req-migration.md old-version="2.x" version="3.0.0" message="These annotations were renamed to add an `Is` prefix to avoid name collisions with common Java types" %}
+{% include req-migration.md old-version="2.x" version="3.0.0" message="These annotations were renamed to add an `Is` prefix to avoid name collisions with common Java types, user should update their annotations accordingly." %}
 
 ## `@IsPath`
 

--- a/docs/guide/annotations/path.md
+++ b/docs/guide/annotations/path.md
@@ -1,15 +1,16 @@
 ---
 layout: page
-title: Path, File and Directory Annotations
+title: IsPath, IsFile and IsDirectory Annotations
 ---
+{% include req-migration.md old-version="2.x" version="3.0.0" message="These annotations were renamed to add an `Is` prefix to avoid name collisions with common Java types" %}
 
-## `@Path`
+## `@IsPath`
 
-The `@Path` annotation may be applied to fields annotated with [`@Option`](option.html) and [`@Arguments`](arguments.html) that take filesystem path related arguments to impose various restrictions on those e.g.
+The `@IsPath` annotation may be applied to fields annotated with [`@Option`](option.html) and [`@Arguments`](arguments.html) that take filesystem path related arguments to impose various restrictions on those e.g.
 
 ```java
 @Option(name = "--path", arity = 1)
-@Path(mustExist = true)
+@IsPath(mustExist = true)
 public String pathMustExist;
 ```
 
@@ -19,7 +20,7 @@ We can also restrict the kind of the path e.g.
     
 ```java
 @Option(name = "--file", arity = 1)
-@Path(mustExist = true, kind = PathKind.FILE)
+@IsPath(mustExist = true, kind = PathKind.FILE)
 public String fileMustExit;
 ```
 Requires that the `--file` option be an existing path that references a file.
@@ -28,33 +29,35 @@ Similarly we can also require a directory e.g.
     
 ```java
 @Option(name = "--directory", arity = 1)
-@Path(mustExist = true, kind = PathKind.DIRECTORY)
+@IsPath(mustExist = true, kind = PathKind.DIRECTORY)
 public String dirMustExist;
 ```
+
 Note that there is also a `PathKind.ANY` if we allow either files or directories.
 
 Additionally we can specify restrictions on the access mode of the path:
     
 ```java
 @Option(name = "--readable", arity = 1)
-@Path(mustExist = false, readable = true, writable = false, executable = false)
+@IsPath(mustExist = false, readable = true, writable = false, executable = false)
 public String readable;
     
 @Option(name = "--writable", arity = 1)
-@Path(mustExist = false, writable = true, readable = false, executable = false)
+@IsPath(mustExist = false, writable = true, readable = false, executable = false)
 public String writable;
     
 @Option(name = "--executable", arity = 1)
-@Path(mustExist = false, executable = true, readable = false, writable = false)
+@IsPath(mustExist = false, executable = true, readable = false, writable = false)
 public String executable;
 ```
+
 In the above examples we use the `readable`, `writable` and `executable` fields of the annotation to specify the access modes that the path must support.
 
-## `@File` and `@Directory`
+## `@IsFile` and `@IsDirectory`
 
-These annotations function the same as the above described `@Path` annotation except that the `kind` field is not available since it is implied by the name of the annotation.
+These annotations function the same as the above described `@IsPath` annotation except that the `kind` field is not available since it is implied by the name of the annotation.
 
-So `@File` functions the same as `@Path(kind = PathKind.FILE)` and `@Directory` the same as `@Path(kind = PathKind.DIRECTORY)` 
+So `@IsFile` functions the same as `@IsPath(kind = PathKind.FILE)` and `@IsDirectory` the same as `@IsPath(kind = PathKind.DIRECTORY)` 
 
 ### Related Annotations
 


### PR DESCRIPTION
Adds an `Is` prefix onto those annotations to avoid naming conflicts with common Java classes.