### PR TITLE
Add new @NoOptionLikeValues restriction annotation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 install: true
 jdk: 
   - openjdk8
-  - openjdk9
-  - openjdk10
   - openjdk11
 env:
   - MAVEN_OPTS="-Dhttps.protocol=TLSv1.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Restriction Improvements
     - New `@NoOptionLikeValues` restriction for explicitly rejecting values that look like options i.e. start with
-      `-` or `--` but didn't match a defined option (#112)
+      `-` or `--` but didn't match a defined option e.g. user typos (#112)
 
 ## 2.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Airline - Change Log
 
+## 2.8.4
+
+- Restriction Improvements
+    - New `@NoOptionLikeValues` restriction for explicitly rejecting values that look like options i.e. start with
+      `-` or `--` but didn't match a defined option (#112)
+
 ## 2.8.3
 
 - Parser Improvements

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/NoOptionLikeValues.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/NoOptionLikeValues.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline.annotations.restrictions;
+
+import static java.lang.annotation.ElementType.FIELD;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that marks that values provided for options/arguments musn't look like possible options
+ * 
+ * @author rvesse
+ *
+ */
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({ FIELD })
+public @interface NoOptionLikeValues {
+
+    /**
+     * Indicates the prefixes that will be used to detect values that look like options. If a value starts with
+     * <strong>any</strong> of these prefixes then it will be rejected.
+     * <p>
+     * If not specified then the default prefixes are {@code -} and {@code --}
+     * </p>
+     * 
+     * @return Option Prefixes
+     */
+    String[] optionPrefixes() default { "-", "--" };
+}

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/NoOptionLikeValues.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/NoOptionLikeValues.java
@@ -16,18 +16,44 @@
 package com.github.rvesse.airline.annotations.restrictions;
 
 import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * An annotation that marks that values provided for options/arguments musn't look like possible options
- * 
- * @author rvesse
+ * An annotation that marks that values provided for options/arguments <strong>MUST NOT</strong> look like possible
+ * options.
+ * <p>
+ * Remember that Airline parsers are generally conservative in that if they are trying to consume values and the next
+ * value matches a known option they will produce an appropriate error.  However this does not protect against user
+ * error, e.g. user making a typo in their options, in that case the value would still be consumed.  This can often lead
+ * to unexpected behaviour because it can cause something the user expected to be an option to be treated as a value
+ * meaning all subsequent arguments provided may also be misinterpreted.  Sometimes this can cause many parser errors to
+ * be produced, none of which actually identified the root cause of the problems. Using this restriction prevents that
+ * scenario since any value that looks like it could be an option will not be consumed and produce an appropriate error
+ * instead.
+ * </p>
+ * <p>
+ * This restriction can be used as either an Option/Argument level restriction, or as a Global restriction.  When used
+ * as an Option/Argument level restriction it operates upon the raw values prior to their parsing into the appropriate
+ * value type for the Option/Argument.  When used as a Global restriction it operates upon the typed values that have
+ * been assigned to each parsed option.
+ * </p>
+ * <p>
+ * This distinction can be quite important when options/arguments can legitimately take values that appear option like.
+ * For example consider an option typed as {@link Integer}, users may legitimately expect to be able to pass in negative
+ * numbers to this option.  If that option were to have this restriction applied directly to it any negative numbers
+ * would be rejected since {@code -} is considered an option prefix.  However were this restriction instead applied at
+ * the command/CLI level, i.e. made global, then negative numbers would be permitted because it would only consider the
+ * typed values for the options.  As the typed value for the option is an {@link Integer} the restriction would not be
+ * applied to it.
+ * </p>
  *
+ * @author rvesse
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@Target({ FIELD })
+@Target({FIELD, TYPE})
 public @interface NoOptionLikeValues {
 
     /**
@@ -36,8 +62,8 @@ public @interface NoOptionLikeValues {
      * <p>
      * If not specified then the default prefixes are {@code -} and {@code --}
      * </p>
-     * 
+     *
      * @return Option Prefixes
      */
-    String[] optionPrefixes() default { "-", "--" };
+    String[] optionPrefixes() default {"-", "--"};
 }

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/common/NoOptionLikeValuesRestriction.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/common/NoOptionLikeValuesRestriction.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.rvesse.airline.restrictions.common;
+
+import java.util.Locale;
+
+import com.github.rvesse.airline.model.ArgumentsMetadata;
+import com.github.rvesse.airline.model.OptionMetadata;
+import com.github.rvesse.airline.parser.ParseState;
+import com.github.rvesse.airline.parser.errors.ParseRestrictionViolatedException;
+import com.github.rvesse.airline.restrictions.AbstractCommonRestriction;
+import com.github.rvesse.airline.utils.AirlineUtils;
+
+/**
+ * A restriction that enforces that values <strong>CANNOT</strong> look like options
+ * 
+ * @author rvesse
+ *
+ */
+public class NoOptionLikeValuesRestriction extends StartsWithRestriction {
+
+    public NoOptionLikeValuesRestriction(String[] prefixes) {
+        super(false, Locale.ROOT, prefixes);
+    }
+
+    @Override
+    protected boolean isValid(String value) {
+        return !super.isValid(value);
+    }
+
+    @Override
+    protected <T> ParseRestrictionViolatedException violated(ParseState<T> state, OptionMetadata option, String value) {
+        throw new ParseRestrictionViolatedException(
+                "Option %s value '%s' has value '%s' which appears to be an option, but was not recognized as such, was this option entered incorrectly?",
+                AirlineUtils.first(option.getOptions()), AbstractCommonRestriction.getOptionTitle(state, option),
+                value);
+    }
+
+    @Override
+    protected <T> ParseRestrictionViolatedException violated(ParseState<T> state, ArgumentsMetadata arguments,
+            String value) {
+        throw new ParseRestrictionViolatedException(
+                "Argument '%s' has value '%s' which appears to be an option, but was not recognized as such, was this option entered incorrectly?",
+                AbstractCommonRestriction.getArgumentTitle(state, arguments), value);
+    }
+
+}

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/common/NoOptionLikeValuesRestriction.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/common/NoOptionLikeValuesRestriction.java
@@ -13,25 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.github.rvesse.airline.restrictions.common;
 
 import java.util.Locale;
 
+import com.github.rvesse.airline.help.sections.HelpFormat;
 import com.github.rvesse.airline.model.ArgumentsMetadata;
 import com.github.rvesse.airline.model.OptionMetadata;
 import com.github.rvesse.airline.parser.ParseState;
 import com.github.rvesse.airline.parser.errors.ParseRestrictionViolatedException;
 import com.github.rvesse.airline.restrictions.AbstractCommonRestriction;
+import com.github.rvesse.airline.restrictions.GlobalRestriction;
 import com.github.rvesse.airline.utils.AirlineUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * A restriction that enforces that values <strong>CANNOT</strong> look like options
- * 
- * @author rvesse
+ * <p>
+ * Please see {@link com.github.rvesse.airline.annotations.restrictions.NoOptionLikeValues} for more discussion of how
+ * this restriction applies.
+ * </p>
  *
+ * @author rvesse
  */
-public class NoOptionLikeValuesRestriction extends StartsWithRestriction {
+public class NoOptionLikeValuesRestriction extends StartsWithRestriction implements GlobalRestriction {
 
     public NoOptionLikeValuesRestriction(String[] prefixes) {
         super(false, Locale.ROOT, prefixes);
@@ -52,10 +57,52 @@ public class NoOptionLikeValuesRestriction extends StartsWithRestriction {
 
     @Override
     protected <T> ParseRestrictionViolatedException violated(ParseState<T> state, ArgumentsMetadata arguments,
-            String value) {
+                                                             String value) {
         throw new ParseRestrictionViolatedException(
                 "Argument '%s' has value '%s' which appears to be an option, but was not recognized as such, was this option entered incorrectly?",
                 AbstractCommonRestriction.getArgumentTitle(state, arguments), value);
     }
 
+    @Override
+    public <T> void validate(ParseState<T> state) {
+        for (Pair<OptionMetadata, Object> parsedOption : state.getParsedOptions()) {
+            if (parsedOption.getValue() instanceof String) {
+                String value = (String) parsedOption.getValue();
+                if (!isValid(value)) {
+                    violated(state, parsedOption.getKey(), value);
+                }
+            }
+        }
+        for (Object parsedArg : state.getParsedArguments()) {
+            if (parsedArg instanceof String) {
+                String value = (String) parsedArg;
+                if (!isValid(value)) {
+                    violated(state, state.getCommand().getArguments(), value);
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getPreamble() {
+        return null;
+    }
+
+    @Override
+    public HelpFormat getFormat() {
+        return HelpFormat.PROSE;
+    }
+
+    @Override
+    public int numContentBlocks() {
+        return 1;
+    }
+
+    @Override
+    public String[] getContentBlock(int blockNumber) {
+        if (blockNumber != 0)
+            throw new IndexOutOfBoundsException();
+        return new String[]{String.format(
+                "This options value must not look like it could be an option.  Any option-like value will be rejected.")};
+    }
 }

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/factories/StandardGlobalRestrictionsFactory.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/factories/StandardGlobalRestrictionsFactory.java
@@ -19,12 +19,14 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.github.rvesse.airline.annotations.restrictions.NoOptionLikeValues;
 import com.github.rvesse.airline.annotations.restrictions.Unrestricted;
 import com.github.rvesse.airline.annotations.restrictions.global.CommandRequired;
 import com.github.rvesse.airline.annotations.restrictions.global.NoMissingOptionValues;
 import com.github.rvesse.airline.annotations.restrictions.global.NoUnexpectedArguments;
 import com.github.rvesse.airline.restrictions.GlobalRestriction;
 import com.github.rvesse.airline.restrictions.None;
+import com.github.rvesse.airline.restrictions.common.NoOptionLikeValuesRestriction;
 import com.github.rvesse.airline.restrictions.factories.GlobalRestrictionFactory;
 import com.github.rvesse.airline.restrictions.global.CommandRequiredRestriction;
 import com.github.rvesse.airline.restrictions.global.NoMissingOptionValuesRestriction;
@@ -42,6 +44,8 @@ public class StandardGlobalRestrictionsFactory implements GlobalRestrictionFacto
             return new NoMissingOptionValuesRestriction();
         } else if (annotation instanceof NoUnexpectedArguments) {
             return new NoUnexpectedArgumentsRestriction();
+        } else if (annotation instanceof NoOptionLikeValues) {
+            return new NoOptionLikeValuesRestriction(((NoOptionLikeValues) annotation).optionPrefixes());
         }
         return null;
     }
@@ -53,6 +57,7 @@ public class StandardGlobalRestrictionsFactory implements GlobalRestrictionFacto
         supported.add(CommandRequired.class);
         supported.add(NoMissingOptionValues.class);
         supported.add(NoUnexpectedArguments.class);
+        supported.add(NoOptionLikeValues.class);
         return supported;
     }
 

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/factories/StringRestrictionFactory.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/factories/StringRestrictionFactory.java
@@ -24,6 +24,7 @@ import com.github.rvesse.airline.annotations.restrictions.EndsWith;
 import com.github.rvesse.airline.annotations.restrictions.ExactLength;
 import com.github.rvesse.airline.annotations.restrictions.MaxLength;
 import com.github.rvesse.airline.annotations.restrictions.MinLength;
+import com.github.rvesse.airline.annotations.restrictions.NoOptionLikeValues;
 import com.github.rvesse.airline.annotations.restrictions.NotBlank;
 import com.github.rvesse.airline.annotations.restrictions.NotEmpty;
 import com.github.rvesse.airline.annotations.restrictions.Pattern;
@@ -31,12 +32,7 @@ import com.github.rvesse.airline.annotations.restrictions.StartsWith;
 import com.github.rvesse.airline.restrictions.AbstractCommonRestriction;
 import com.github.rvesse.airline.restrictions.ArgumentsRestriction;
 import com.github.rvesse.airline.restrictions.OptionRestriction;
-import com.github.rvesse.airline.restrictions.common.EndsWithRestriction;
-import com.github.rvesse.airline.restrictions.common.LengthRestriction;
-import com.github.rvesse.airline.restrictions.common.NotBlankRestriction;
-import com.github.rvesse.airline.restrictions.common.NotEmptyRestriction;
-import com.github.rvesse.airline.restrictions.common.PatternRestriction;
-import com.github.rvesse.airline.restrictions.common.StartsWithRestriction;
+import com.github.rvesse.airline.restrictions.common.*;
 
 public class StringRestrictionFactory implements ArgumentsRestrictionFactory, OptionRestrictionFactory {
 
@@ -63,6 +59,9 @@ public class StringRestrictionFactory implements ArgumentsRestrictionFactory, Op
         } else if (annotation instanceof ExactLength) {
             ExactLength el = (ExactLength) annotation;
             return new LengthRestriction(el.length(), el.length());
+        } else if (annotation instanceof NoOptionLikeValues) {
+            NoOptionLikeValues noOptionLikeValues = (NoOptionLikeValues) annotation;
+            return new NoOptionLikeValuesRestriction(noOptionLikeValues.optionPrefixes());
         } else if (annotation instanceof NotBlank) {
             return new NotBlankRestriction();
         } else if (annotation instanceof NotEmpty) {
@@ -83,6 +82,7 @@ public class StringRestrictionFactory implements ArgumentsRestrictionFactory, Op
         supported.add(MaxLength.class);
         supported.add(MinLength.class);
         supported.add(ExactLength.class);
+        supported.add(NoOptionLikeValues.class);
         supported.add(NotBlank.class);
         supported.add(NotEmpty.class);
         supported.add(EndsWith.class);

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Args1NotOptionLike.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Args1NotOptionLike.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline.restrictions;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.restrictions.NoOptionLikeValues;
+import com.github.rvesse.airline.args.Args1;
+
+@Command(name = "args")
+@NoOptionLikeValues
+public class Args1NotOptionLike extends Args1 {
+}

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Numbers.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Numbers.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline.restrictions;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+
+@Command(name = "numbers")
+public class Numbers {
+
+    @Option(name = { "-l", "--long"})
+    public long l;
+}

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/NumbersNoOptionLike.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/NumbersNoOptionLike.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline.restrictions;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.NoOptionLikeValues;
+
+@Command(name = "numbers")
+public class NumbersNoOptionLike {
+
+    @Option(name = { "-l", "--long"})
+    @NoOptionLikeValues
+    public long l;
+}

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/NumbersNoOptionLikeGlobal.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/NumbersNoOptionLikeGlobal.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline.restrictions;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.NoOptionLikeValues;
+
+@Command(name = "numbers")
+@NoOptionLikeValues
+public class NumbersNoOptionLikeGlobal {
+
+    @Option(name = { "-l", "--long"})
+    public long l;
+}

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Strings.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Strings.java
@@ -21,12 +21,14 @@ import java.util.List;
 import javax.inject.Inject;
 
 import com.github.rvesse.airline.HelpOption;
+import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.EndsWith;
 import com.github.rvesse.airline.annotations.restrictions.ExactLength;
 import com.github.rvesse.airline.annotations.restrictions.MaxLength;
 import com.github.rvesse.airline.annotations.restrictions.MinLength;
+import com.github.rvesse.airline.annotations.restrictions.NoOptionLikeValues;
 import com.github.rvesse.airline.annotations.restrictions.NotBlank;
 import com.github.rvesse.airline.annotations.restrictions.NotEmpty;
 import com.github.rvesse.airline.annotations.restrictions.Pattern;
@@ -87,6 +89,18 @@ public class Strings {
     @Option(name = "--urls-ci")
     @StartsWith(ignoreCase = true, prefixes = { "http", "https", "ftp" })
     public List<String> urlsCaseInsensitive = new ArrayList<>();
+    
+    @Option(name = "--not-option-like")
+    @NoOptionLikeValues
+    public List<String> notOptionLike = new ArrayList<>();
+
+    @Option(name = "--not-option-like-long")
+    @NoOptionLikeValues(optionPrefixes = { "--" })
+    public List<String> notOptionLikeLong = new ArrayList<>();
+
+    @Arguments
+    @NoOptionLikeValues
+    public List<String> args = new ArrayList<>();
     
     @Inject
     public HelpOption<Strings> helpOption = new HelpOption<>();

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/StringsNotOptionLike.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/StringsNotOptionLike.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.rvesse.airline.restrictions;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.restrictions.NoOptionLikeValues;
+
+@Command(name = "strings")
+@NoOptionLikeValues
+public class StringsNotOptionLike extends Strings {
+}

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/TestStrings.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/TestStrings.java
@@ -282,4 +282,56 @@ public class TestStrings {
         Assert.assertEquals(cmd.urlsCaseInsensitive.size(), 1);
         Assert.assertEquals(cmd.urlsCaseInsensitive.get(0), "HTTP://test.com");
     }
+    
+    @Test
+    public void no_option_like_01() {
+        Strings cmd = parser().parse("--not-option-like", "foo", "--not-option-like", "bar");
+        Assert.assertEquals(cmd.notOptionLike.size(), 2);
+        Assert.assertEquals(cmd.notOptionLike.get(0), "foo");
+        Assert.assertEquals(cmd.notOptionLike.get(1), "bar");
+    }
+    
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_02() {
+        parser().parse("--not-option-like", "--foo");
+    }
+    
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_03() {
+        parser().parse("--not-option-like", "-f");
+    }
+
+    @Test
+    public void no_option_like_04() {
+        // Using @NotOptionLikeValues but restricting the option prefixes to -- so short form style options are allowed
+        Strings cmd = parser().parse("--not-option-like-long", "-f");
+        Assert.assertEquals(cmd.notOptionLikeLong.size(), 1);
+        Assert.assertEquals(cmd.notOptionLikeLong.get(0), "-f");
+    }
+
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_05() {
+        // Using @NotOptionLikeValues but restricting the option prefixes to -- so long form style options are forbidden
+        parser().parse("--not-option-like-long", "--foo");
+    }
+
+    @Test
+    public void no_option_like_06() {
+        Strings cmd = parser().parse("foo", "bar");
+        Assert.assertEquals(cmd.args.size(), 2);
+        Assert.assertEquals(cmd.args.get(0), "foo");
+        Assert.assertEquals(cmd.args.get(1), "bar");
+    }
+
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_07() {
+        // Using @NotOptionLikeValues on arguments so unrecognized options are rejected
+        parser().parse("--unrecognized");
+    }
+
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_08() {
+        // Using @NotOptionLikeValues on arguments so unrecognized options are rejected
+        parser().parse("--foo");
+    }
 }

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/TestStrings.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/TestStrings.java
@@ -15,6 +15,7 @@
  */
 package com.github.rvesse.airline.restrictions;
 
+import com.github.rvesse.airline.args.Args1;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -26,6 +27,10 @@ public class TestStrings {
 
     private SingleCommand<Strings> parser() {
         return TestingUtil.singleCommandParser(Strings.class);
+    }
+
+    private SingleCommand<StringsNotOptionLike> parserNotOptionLike() {
+        return TestingUtil.singleCommandParser(StringsNotOptionLike.class);
     }
 
     @Test
@@ -115,7 +120,7 @@ public class TestStrings {
     public void exact_length_invalid_02() {
         parser().parse("--exact", "foo");
     }
-    
+
     @Test
     public void range_exact_length_valid() {
         Strings cmd = parser().parse("--range-exact", "foob");
@@ -170,14 +175,14 @@ public class TestStrings {
     public void pattern_case_insensitive_invalid() {
         parser().parse("--other", "test");
     }
-    
+
     @Test
     public void ends_with_01() {
         Strings cmd = parser().parse("--images", "test.jpg");
         Assert.assertEquals(cmd.images.size(), 1);
         Assert.assertEquals(cmd.images.get(0), "test.jpg");
     }
-    
+
     @Test
     public void ends_with_02() {
         Strings cmd = parser().parse("--images", "test.jpg", "--images", "test.png", "--images", "test.gif");
@@ -186,25 +191,25 @@ public class TestStrings {
         Assert.assertEquals(cmd.images.get(1), "test.png");
         Assert.assertEquals(cmd.images.get(2), "test.gif");
     }
-    
+
     @Test(expectedExceptions = ParseRestrictionViolatedException.class)
     public void ends_with_03() {
         parser().parse("--images", "test.txt");
     }
-    
+
     @Test(expectedExceptions = ParseRestrictionViolatedException.class)
     public void ends_with_04() {
         // Case sensitive so fails
         parser().parse("--images", "test.JPG");
     }
-    
+
     @Test
     public void ends_with_case_insensitive_01() {
         Strings cmd = parser().parse("--images-ci", "test.jpg");
         Assert.assertEquals(cmd.imagesCaseInsensitive.size(), 1);
         Assert.assertEquals(cmd.imagesCaseInsensitive.get(0), "test.jpg");
     }
-    
+
     @Test
     public void ends_with_case_insensitive_02() {
         Strings cmd = parser().parse("--images-ci", "test.jpg", "--images-ci", "test.PNG", "--images-ci", "test.GiF");
@@ -213,12 +218,12 @@ public class TestStrings {
         Assert.assertEquals(cmd.imagesCaseInsensitive.get(1), "test.PNG");
         Assert.assertEquals(cmd.imagesCaseInsensitive.get(2), "test.GiF");
     }
-    
+
     @Test(expectedExceptions = ParseRestrictionViolatedException.class)
     public void ends_with_case_insensitive_03() {
         parser().parse("--images-ci", "test.txt");
     }
-    
+
     @Test
     public void ends_with_case_insensitive_04() {
         // Case insensitive so passes
@@ -226,55 +231,57 @@ public class TestStrings {
         Assert.assertEquals(cmd.imagesCaseInsensitive.size(), 1);
         Assert.assertEquals(cmd.imagesCaseInsensitive.get(0), "test.JPG");
     }
-    
+
     @Test
     public void starts_with_01() {
         Strings cmd = parser().parse("--urls", "http://test.com");
         Assert.assertEquals(cmd.urls.size(), 1);
         Assert.assertEquals(cmd.urls.get(0), "http://test.com");
     }
-    
+
     @Test
     public void starts_with_02() {
-        Strings cmd = parser().parse("--urls", "http://test.com", "--urls", "https://secure.com", "--urls", "ftp://uploads.com");
+        Strings cmd = parser().parse("--urls", "http://test.com", "--urls", "https://secure.com", "--urls",
+                                     "ftp://uploads.com");
         Assert.assertEquals(cmd.urls.size(), 3);
         Assert.assertEquals(cmd.urls.get(0), "http://test.com");
         Assert.assertEquals(cmd.urls.get(1), "https://secure.com");
         Assert.assertEquals(cmd.urls.get(2), "ftp://uploads.com");
     }
-    
+
     @Test(expectedExceptions = ParseRestrictionViolatedException.class)
     public void starts_with_03() {
         parser().parse("--urls", "test.txt");
     }
-    
+
     @Test(expectedExceptions = ParseRestrictionViolatedException.class)
     public void starts_with_04() {
         // Case sensitive so fails
         parser().parse("--urls", "HTTP://test.com");
     }
-    
+
     @Test
     public void starts_with_case_insensitive_01() {
         Strings cmd = parser().parse("--urls-ci", "http://test.com");
         Assert.assertEquals(cmd.urlsCaseInsensitive.size(), 1);
         Assert.assertEquals(cmd.urlsCaseInsensitive.get(0), "http://test.com");
     }
-    
+
     @Test
     public void starts_with_case_insensitive_02() {
-        Strings cmd = parser().parse("--urls-ci", "http://test.com", "--urls-ci", "HTTPS://secure.com", "--urls-ci", "FtP://uploads.com");
+        Strings cmd = parser().parse("--urls-ci", "http://test.com", "--urls-ci", "HTTPS://secure.com", "--urls-ci",
+                                     "FtP://uploads.com");
         Assert.assertEquals(cmd.urlsCaseInsensitive.size(), 3);
         Assert.assertEquals(cmd.urlsCaseInsensitive.get(0), "http://test.com");
         Assert.assertEquals(cmd.urlsCaseInsensitive.get(1), "HTTPS://secure.com");
         Assert.assertEquals(cmd.urlsCaseInsensitive.get(2), "FtP://uploads.com");
     }
-    
+
     @Test(expectedExceptions = ParseRestrictionViolatedException.class)
     public void starts_with_case_insensitive_03() {
         parser().parse("--urls-ci", "urn:foo");
     }
-    
+
     @Test
     public void starts_with_case_insensitive_04() {
         // Case insensitive so passes
@@ -282,7 +289,7 @@ public class TestStrings {
         Assert.assertEquals(cmd.urlsCaseInsensitive.size(), 1);
         Assert.assertEquals(cmd.urlsCaseInsensitive.get(0), "HTTP://test.com");
     }
-    
+
     @Test
     public void no_option_like_01() {
         Strings cmd = parser().parse("--not-option-like", "foo", "--not-option-like", "bar");
@@ -290,12 +297,12 @@ public class TestStrings {
         Assert.assertEquals(cmd.notOptionLike.get(0), "foo");
         Assert.assertEquals(cmd.notOptionLike.get(1), "bar");
     }
-    
+
     @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
     public void no_option_like_02() {
         parser().parse("--not-option-like", "--foo");
     }
-    
+
     @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
     public void no_option_like_03() {
         parser().parse("--not-option-like", "-f");
@@ -333,5 +340,72 @@ public class TestStrings {
     public void no_option_like_08() {
         // Using @NotOptionLikeValues on arguments so unrecognized options are rejected
         parser().parse("--foo");
+    }
+
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_global_01() {
+        parserNotOptionLike().parse("--not-empty", "--foo");
+    }
+
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_global_02() {
+        parserNotOptionLike().parse("--not-blank", "--foo");
+    }
+
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_global_03() {
+        parserNotOptionLike().parse("--min", "--foo");
+    }
+
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_global_04() {
+        // Both an option and global restriction apply
+        parserNotOptionLike().parse("--not-option-like", "--foo");
+    }
+
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_global_05() {
+        // Here both an option and global restriction apply
+        // The option restriction will pass since it only looks for the -- prefix but the global restriction will
+        // reject it because it is using the default of both - and -- prefixes
+        parserNotOptionLike().parse("--not-option-like-long", "-foo");
+    }
+
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_global_06() {
+        // Here both an option and global restriction apply
+        parserNotOptionLike().parse("-foo");
+    }
+
+    @Test
+    public void no_option_like_global_07() {
+        SingleCommand<Args1> parser = TestingUtil.singleCommandParser(Args1.class);
+        // No restrictions on this so allowed
+        Args1 cmd = parser.parse("-foo");
+        Assert.assertEquals(cmd.parameters.size(), 1);
+        Assert.assertEquals(cmd.parameters.get(0), "-foo");
+    }
+
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_global_08() {
+        SingleCommand<Args1NotOptionLike> parser = TestingUtil.singleCommandParser(Args1NotOptionLike.class);
+        // Global restriction so rejected
+        parser.parse("-foo");
+    }
+
+    @Test(expectedExceptions = ParseRestrictionViolatedException.class, expectedExceptionsMessageRegExp = ".*appears to be an option.*")
+    public void no_option_like_numerics_01() {
+        SingleCommand<NumbersNoOptionLike> parser = TestingUtil.singleCommandParser(NumbersNoOptionLike.class);
+        // Negative number is rejected because @NoOptionLikeValues is directly applied so inspects the raw value
+        parser.parse("--long", "-1");
+    }
+
+    @Test
+    public void no_option_like_numerics_02() {
+        SingleCommand<NumbersNoOptionLikeGlobal> parser = TestingUtil.singleCommandParser(NumbersNoOptionLikeGlobal.class);
+        // Negative number is allowed because when used as a global restriction it inspects the typed values and ignores
+        // anything that is not a string
+        NumbersNoOptionLikeGlobal cmd = parser.parse("--long", "-1");
+        Assert.assertEquals(cmd.l, -1L);
     }
 }

--- a/airline-maven-plugin/.gitignore
+++ b/airline-maven-plugin/.gitignore
@@ -1,0 +1,2 @@
+/.apt_generated/
+/.apt_generated_tests/

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -86,6 +86,7 @@
                   <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/starts-with.html">@StartsWith</a></li>
                   <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/ends-with.html">@EndsWith</a></li>
                   <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/pattern.html">@Pattern</a></li>
+                  <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/no-option-like-values.html">@NoOptionLikeValues</a></li>
                   <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/max-length.html">@MaxLength</a></li>
                   <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/min-length.html">@MinLength</a></li>
                   <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/exact-length.html">@ExactLength</a></li>

--- a/docs/guide/annotations/no-option-like-values.md
+++ b/docs/guide/annotations/no-option-like-values.md
@@ -16,7 +16,7 @@ annotated fields rather than any kind of error being issued.
 public List<String> args = new ArrayList<>();
 ```
 
-Here is a user tries to pass `--foo` into our command, and that isn't an option, it would result in an error.  If 
+Here if a user tries to pass `--foo` into our command, and that isn't an option, it would result in an error.  If 
 `@NoOptionLikeValues` is not applied then `--foo` would have been captured as an argument.
 
 ### Customising Option Prefixes

--- a/docs/guide/annotations/no-option-like-values.md
+++ b/docs/guide/annotations/no-option-like-values.md
@@ -1,0 +1,40 @@
+---
+layout: page
+title: NoOptionLikeValues Annotation
+---
+
+## `@NoOptionLikeValues`
+
+The `@NoOptionLikeValues` annotation can be used to require that values don't look like options.  Note that the 
+Airline parsers are non-greedy so won't consume values that are clearly options.  However, sometimes users may make
+typos when providing options in which case those values would get consumed by other `@Option`/`@Arguments` 
+annotated fields rather than any kind of error being issued.
+
+```java
+@Arguments(title = "Arg")
+@NoOptionLikeValues
+public List<String> args = new ArrayList<>();
+```
+
+Here is a user tries to pass `--foo` into our command, and that isn't an option, it would result in an error.  If 
+`@NoOptionLikeValues` is not applied then `--foo` would have been captured as an argument.
+
+### Customising Option Prefixes
+
+If you are customising the option parsers, or defining options using some non-standard prefix format, then you can 
+choose to customise the option prefixes that are used to detect values that look like options e.g.
+
+```java
+@Arguments(title = "Arg")
+@NoOptionLikeValues(optionPrefixes = { "/" })
+public List<String> args = new ArrayList<>();
+```
+
+Here values starting with `/` would be rejected as being option like.
+
+### Related Annotations
+
+If you have a prefixes you need to enforce, rather than reject, then use the [`@StartsWith`](starts-with.html) 
+annotation.  
+For more complex string value enforcement you can also use the regular expression based [`@Pattern`](pattern.html)
+annotation.

--- a/docs/guide/annotations/no-option-like-values.md
+++ b/docs/guide/annotations/no-option-like-values.md
@@ -1,5 +1,6 @@
 ---
-layout: page title: NoOptionLikeValues Annotation
+layout: page 
+title: NoOptionLikeValues Annotation
 ---
 
 ## `@NoOptionLikeValues`

--- a/docs/guide/annotations/no-option-like-values.md
+++ b/docs/guide/annotations/no-option-like-values.md
@@ -1,40 +1,70 @@
 ---
-layout: page
-title: NoOptionLikeValues Annotation
+layout: page title: NoOptionLikeValues Annotation
 ---
 
 ## `@NoOptionLikeValues`
 
-The `@NoOptionLikeValues` annotation can be used to require that values don't look like options.  Note that the 
-Airline parsers are non-greedy so won't consume values that are clearly options.  However, sometimes users may make
-typos when providing options in which case those values would get consumed by other `@Option`/`@Arguments` 
+The `@NoOptionLikeValues` annotation can be used to require that values don't look like options. Note that the Airline
+parsers are non-greedy so won't consume values that are clearly options. However, sometimes users may make typos when
+providing options in which case those values would get consumed by other `@Option`/`@Arguments`
 annotated fields rather than any kind of error being issued.
 
 ```java
 @Arguments(title = "Arg")
 @NoOptionLikeValues
-public List<String> args = new ArrayList<>();
+public List<String> args=new ArrayList<>();
 ```
 
-Here if a user tries to pass `--foo` into our command, and that isn't an option, it would result in an error.  If 
+Here if a user tries to pass `--foo` into our command, and that isn't an option, it would result in an error. If
 `@NoOptionLikeValues` is not applied then `--foo` would have been captured as an argument.
 
 ### Customising Option Prefixes
 
-If you are customising the option parsers, or defining options using some non-standard prefix format, then you can 
+If you are customising the option parsers, or defining options using some non-standard prefix format, then you can
 choose to customise the option prefixes that are used to detect values that look like options e.g.
 
 ```java
 @Arguments(title = "Arg")
-@NoOptionLikeValues(optionPrefixes = { "/" })
-public List<String> args = new ArrayList<>();
+@NoOptionLikeValues(optionPrefixes = {"/"})
+public List<String> args=new ArrayList<>();
 ```
 
 Here values starting with `/` would be rejected as being option like.
 
+### Use as a Global Restriction
+
+Note that using this restriction **MAY NOT** make sense for certain option types, for example consider the following
+option definition:
+
+```java
+@Option(name = "--limit",
+        title = "Limit",
+        description = "Specifies a limit on results, a negative value is treated as unlimited.")
+@NoOptionLikeValues
+public long limit=-1;
+```
+
+Here the intent is to allow negative values to be passed to this option, however since a negative number will start with
+the `-` character it would always be treated as an option like value and rejected by this restriction. This is because
+when applied to an `@Option`/`@Arguments` annotated field it operates over the raw unparsed values. So a user could not
+call your command with `--limit -1` because the `-1` would be considered an option like value and be rejected by this
+restriction.
+
+Now this specific case could be avoided by customising the option prefixes as already shown, but if you want to use this
+restriction broadly across many options that quickly becomes unwieldy.
+
+Instead of applying this restriction to each option/argument individually you can instead apply it directly to your
+`@Command`/`@Cli` annotated class. When applied at the class level this becomes a [Global Restriction](..
+/restrictions/global.html) instead. As a Global Restriction it gets to inspect the typed parsed values of options and
+arguments at the end of parsing. When it does this it **ONLY** considers options and arguments whose actual type
+is `String`, the assumption being that any other type would already have handled a bad value when it was parsed. So for
+the above example if a user invoked your command with `--limit --typo` then `--typo` would have resulted in a parser
+error trying to convert it into an integer. Whereas `--limit -1` would now be acceptable because the typed value is not
+a string.
+
 ### Related Annotations
 
-If you have a prefixes you need to enforce, rather than reject, then use the [`@StartsWith`](starts-with.html) 
+If you have a prefixes you need to enforce, rather than reject, then use the [`@StartsWith`](starts-with.html)
 annotation.  
 For more complex string value enforcement you can also use the regular expression based [`@Pattern`](pattern.html)
 annotation.


### PR DESCRIPTION
This handles the case where option-like values, whether intentional or
typo'd by the user, that are passed to options/arguments should be rejected.

This is a solution to the issue described in #112.

Users can use the new `@NoOptionLikeValues` annotation to indicate that an 
`@Option`/`@Arguments` annotated field will reject any values that look like 
they are options **BUT** did not match a defined option.  The set of prefixes 
used to consider a value being option like is configurable to deal with users 
who have unusual/non-standard option naming schemes.