### PR TITLE
Add @RequiredUnlessEnvironment restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Airline - Change Log
 
+## 2.8.5
+
+- Restriction Improvements
+    - New `@RequiredUnlessEnvironment` restriction for making an option/argument required only if one/more 
+      environment variables are not set
+
 ## 2.8.4
 
 - Restriction Improvements

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/Required.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/Required.java
@@ -1,17 +1,14 @@
 /**
  * Copyright (C) 2010-16 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package com.github.rvesse.airline.annotations.restrictions;
 
@@ -23,13 +20,12 @@ import java.lang.annotation.Target;
 /**
  * An annotation that indicates that an option/arguments is required
  * <p>
- * If you have more complex requirement criteria then you may wish to use
- * {@link RequiredOnlyIf}, {@link RequireSome} or {@link RequireOnlyOne}
- * instead.
+ * If you have more complex requirement criteria then you may wish to use {@link RequiredOnlyIf}, {@link RequireSome},
+ * {@link RequireOnlyOne} or {@link RequiredUnlessEnvironment} instead.
  * </p>
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@Target({ FIELD })
+@Target({FIELD})
 public @interface Required {
 
 }

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/Required.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/Required.java
@@ -1,14 +1,17 @@
 /**
  * Copyright (C) 2010-16 the original author or authors.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.github.rvesse.airline.annotations.restrictions;
 

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/RequiredUnlessEnvironment.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/RequiredUnlessEnvironment.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.github.rvesse.airline.annotations.restrictions;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+
+/**
+ * An annotation that indicates that an option/arguments is required <strong>UNLESS</strong> a specific environment
+ * variable is set.
+ * <p>
+ * This is intended for situations where your options are being populated by default values taken from environment
+ * variables and you only require the option if a suitable default is not already provided by the environment.
+ * </p>
+ * <p>
+ * If you have other requirement criteria then you may wish to use {@link Required}, {@link RequiredOnlyIf}, {@link
+ * RequireSome} or {@link RequireOnlyOne} instead.
+ * </p>
+ */
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({FIELD})
+public @interface RequiredUnlessEnvironment {
+    /**
+     * Specifies the name(s) of the environment variable that when present renders the option not required
+     *
+     * @return Name(s) of the environment variables
+     */
+    public String[] variables();
+}

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/RequiredUnlessEnvironment.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/restrictions/RequiredUnlessEnvironment.java
@@ -1,14 +1,17 @@
 /**
  * Copyright (C) 2010-16 the original author or authors.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.github.rvesse.airline.annotations.restrictions;
 

--- a/airline-core/src/main/java/com/github/rvesse/airline/parser/errors/ParseOptionMissingException.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/parser/errors/ParseOptionMissingException.java
@@ -31,6 +31,11 @@ public class ParseOptionMissingException extends ParseRestrictionViolatedExcepti
         this.optionTitle = optionTitle;
     }
 
+    public ParseOptionMissingException(String optionTitle, String unlessCondition) {
+        super("Required option '%s' is missing and %s", optionTitle, unlessCondition);
+        this.optionTitle = optionTitle;
+    }
+
     public String getOptionTitle()
     {
         return optionTitle;

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/factories/RequireFromRestrictionFactory.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/factories/RequireFromRestrictionFactory.java
@@ -17,16 +17,20 @@ package com.github.rvesse.airline.restrictions.factories;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.github.rvesse.airline.annotations.restrictions.MutuallyExclusiveWith;
 import com.github.rvesse.airline.annotations.restrictions.RequireOnlyOne;
 import com.github.rvesse.airline.annotations.restrictions.RequireSome;
+import com.github.rvesse.airline.annotations.restrictions.RequiredUnlessEnvironment;
+import com.github.rvesse.airline.restrictions.ArgumentsRestriction;
 import com.github.rvesse.airline.restrictions.OptionRestriction;
 import com.github.rvesse.airline.restrictions.options.MutuallyExclusiveRestriction;
 import com.github.rvesse.airline.restrictions.options.RequireFromRestriction;
+import com.github.rvesse.airline.restrictions.options.RequiredUnlessEnvironmentRestriction;
 
-public class RequireFromRestrictionFactory implements OptionRestrictionFactory {
+public class RequireFromRestrictionFactory implements OptionRestrictionFactory, ArgumentsRestrictionFactory {
 
     @Override
     public OptionRestriction createOptionRestriction(Annotation annotation) {
@@ -39,6 +43,9 @@ public class RequireFromRestrictionFactory implements OptionRestrictionFactory {
         } else if (annotation instanceof MutuallyExclusiveWith) {
             MutuallyExclusiveWith mutExcl = (MutuallyExclusiveWith) annotation;
             return new MutuallyExclusiveRestriction(mutExcl.tag());
+        } else if (annotation instanceof RequiredUnlessEnvironment) {
+            RequiredUnlessEnvironment reqUnless = (RequiredUnlessEnvironment) annotation;
+            return new RequiredUnlessEnvironmentRestriction(reqUnless.variables());
         }
         return null;
     }
@@ -49,7 +56,21 @@ public class RequireFromRestrictionFactory implements OptionRestrictionFactory {
         supported.add(RequireSome.class);
         supported.add(RequireOnlyOne.class);
         supported.add(MutuallyExclusiveWith.class);
+        supported.add(RequiredUnlessEnvironment.class);
         return supported;
     }
 
+    @Override
+    public ArgumentsRestriction createArgumentsRestriction(Annotation annotation) {
+        if (annotation instanceof RequiredUnlessEnvironment) {
+            RequiredUnlessEnvironment reqUnless = (RequiredUnlessEnvironment) annotation;
+            return new RequiredUnlessEnvironmentRestriction(reqUnless.variables());
+        }
+        return null;
+    }
+
+    @Override
+    public List<Class<? extends Annotation>> supportedArgumentsAnnotations() {
+        return Collections.<Class<? extends Annotation>>singletonList(RequiredUnlessEnvironment.class);
+    }
 }

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/AbstractRequiredUnlessRestriction.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/AbstractRequiredUnlessRestriction.java
@@ -1,14 +1,17 @@
 /**
  * Copyright (C) 2010-16 the original author or authors.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.github.rvesse.airline.restrictions.options;
 

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/AbstractRequiredUnlessRestriction.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/AbstractRequiredUnlessRestriction.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.github.rvesse.airline.restrictions.options;
+
+import com.github.rvesse.airline.model.ArgumentsMetadata;
+import com.github.rvesse.airline.model.OptionMetadata;
+import com.github.rvesse.airline.parser.ParseState;
+import com.github.rvesse.airline.parser.errors.ParseArgumentsMissingException;
+import com.github.rvesse.airline.parser.errors.ParseOptionMissingException;
+import com.github.rvesse.airline.restrictions.AbstractCommonRestriction;
+import com.github.rvesse.airline.utils.AirlineUtils;
+import com.github.rvesse.airline.utils.predicates.parser.ParsedOptionFinder;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A restriction that options/arguments are required unless some other criteria is met
+ */
+public abstract class AbstractRequiredUnlessRestriction extends AbstractCommonRestriction {
+
+    /**
+     * Answers whether the unless condition of the restriction is met
+     * <p>
+     * If the unless condition is met then the restriction will not require the option to be present.
+     * </p>
+     *
+     * @param state  Parse state
+     * @param option Option Metadata
+     * @param <T>    Command Type
+     * @return True if unless condition met, false otherwise
+     */
+    protected abstract <T> boolean unless(ParseState<T> state, OptionMetadata option);
+
+    /**
+     * Answers whether the unless condition of the restriction is met
+     * <p>
+     * If the unless condition is met then the restriction will not require arguments to be present.
+     * </p>
+     *
+     * @param state     Parse state
+     * @param arguments Arguments Metadata
+     * @param <T>       Command Type
+     * @return True if unless condition met, false otherwise
+     */
+    protected abstract <T> boolean unless(ParseState<T> state, ArgumentsMetadata arguments);
+
+    /**
+     * Provides a description of the unless condition, this will be included in the error messages when this restriction
+     * is not met
+     *
+     * @return Unless condition description
+     */
+    protected abstract String unlessDescription();
+
+    @Override
+    public <T> void finalValidate(ParseState<T> state, OptionMetadata option) {
+        if (CollectionUtils.find(state.getParsedOptions(), new ParsedOptionFinder(option)) == null
+                && !unless(state, option)) {
+            throw new ParseOptionMissingException(AirlineUtils.first(option.getOptions()), unlessDescription());
+        }
+    }
+
+    @Override
+    public <T> void finalValidate(ParseState<T> state, ArgumentsMetadata arguments) {
+        if (state.getParsedArguments().isEmpty() && !unless(state, arguments)) {
+            throw new ParseArgumentsMissingException("Required arguments '%s' are missing and %s",
+                                                     arguments.getTitle(), StringUtils.join(arguments.getTitle(), ", "),
+                                                     unlessDescription());
+        }
+    }
+
+}

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/RequiredUnlessEnvironmentRestriction.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/RequiredUnlessEnvironmentRestriction.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.rvesse.airline.restrictions.options;
 
 import com.github.rvesse.airline.model.ArgumentsMetadata;

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/RequiredUnlessEnvironmentRestriction.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/RequiredUnlessEnvironmentRestriction.java
@@ -1,14 +1,17 @@
 /**
  * Copyright (C) 2010-16 the original author or authors.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.github.rvesse.airline.restrictions.options;
 

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/RequiredUnlessEnvironmentRestriction.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/RequiredUnlessEnvironmentRestriction.java
@@ -1,0 +1,54 @@
+package com.github.rvesse.airline.restrictions.options;
+
+import com.github.rvesse.airline.model.ArgumentsMetadata;
+import com.github.rvesse.airline.model.OptionMetadata;
+import com.github.rvesse.airline.parser.ParseState;
+import com.github.rvesse.airline.parser.errors.ParseInvalidRestrictionException;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.IterableUtils;
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RequiredUnlessEnvironmentRestriction extends AbstractRequiredUnlessRestriction {
+
+    private final List<String> variables;
+
+    public RequiredUnlessEnvironmentRestriction(String[] envVars) {
+        this.variables = new ArrayList<>(Arrays.asList(envVars));
+        if (CollectionUtils.isEmpty(this.variables))
+            throw new ParseInvalidRestrictionException(
+                    "A RequiredUnlessEnvironment restriction must specify at least one environment variable.");
+    }
+
+    @Override
+    protected <T> boolean unless(ParseState<T> state, OptionMetadata option) {
+        return IterableUtils.matchesAny(this.variables, new IsEnvVarSet());
+    }
+
+    @Override
+    protected <T> boolean unless(ParseState<T> state, ArgumentsMetadata arguments) {
+        return IterableUtils.matchesAny(this.variables, new IsEnvVarSet());
+    }
+
+    @Override
+    protected String unlessDescription() {
+        if (this.variables.size() > 0) {
+            return String.format("no default values were available from the environment variables %s",
+                                 StringUtils.join(this.variables, ", "));
+        } else {
+            return String.format("no default value was available from the environment variable %s",
+                                 this.variables.get(0));
+        }
+    }
+
+    private static class IsEnvVarSet implements Predicate<String> {
+        @Override
+        public boolean evaluate(String var) {
+            return StringUtils.isNotBlank(System.getenv(var));
+        }
+    }
+}

--- a/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/RequiredUnlessEnvironmentRestriction.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/restrictions/options/RequiredUnlessEnvironmentRestriction.java
@@ -1,20 +1,19 @@
 /**
  * Copyright (C) 2010-16 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package com.github.rvesse.airline.restrictions.options;
 
+import com.github.rvesse.airline.help.sections.HelpFormat;
+import com.github.rvesse.airline.help.sections.HelpHint;
 import com.github.rvesse.airline.model.ArgumentsMetadata;
 import com.github.rvesse.airline.model.OptionMetadata;
 import com.github.rvesse.airline.parser.ParseState;
@@ -28,15 +27,20 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class RequiredUnlessEnvironmentRestriction extends AbstractRequiredUnlessRestriction {
+/**
+ * A restriction that requires an option/argument be set <strong>UNLESS</strong> a suitable environment variable is
+ * specified.
+ */
+public class RequiredUnlessEnvironmentRestriction extends AbstractRequiredUnlessRestriction implements HelpHint {
 
     private final List<String> variables;
 
     public RequiredUnlessEnvironmentRestriction(String[] envVars) {
         this.variables = new ArrayList<>(Arrays.asList(envVars));
-        if (CollectionUtils.isEmpty(this.variables))
+        if (CollectionUtils.isEmpty(this.variables)) {
             throw new ParseInvalidRestrictionException(
                     "A RequiredUnlessEnvironment restriction must specify at least one environment variable.");
+        }
     }
 
     @Override
@@ -51,12 +55,43 @@ public class RequiredUnlessEnvironmentRestriction extends AbstractRequiredUnless
 
     @Override
     protected String unlessDescription() {
-        if (this.variables.size() > 0) {
+        if (this.variables.size() > 1) {
             return String.format("no default values were available from the environment variables %s",
                                  StringUtils.join(this.variables, ", "));
         } else {
             return String.format("no default value was available from the environment variable %s",
                                  this.variables.get(0));
+        }
+    }
+
+    @Override
+    public String getPreamble() {
+        if (this.variables.size() > 1) {
+            return "This option is required unless one of the following environment variables is set:";
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public HelpFormat getFormat() {
+        return this.variables.size() > 1 ? HelpFormat.LIST : HelpFormat.PROSE;
+    }
+
+    @Override
+    public int numContentBlocks() {
+        return 1;
+    }
+
+    @Override
+    public String[] getContentBlock(int blockNumber) {
+        if (this.variables.size() > 1) {
+            return this.variables.toArray(new String[this.variables.size()]);
+        } else {
+            return new String[] {
+                    String.format("This option is required unless the environment variable %s is set.",
+                                  this.variables.get(0))
+            };
         }
     }
 

--- a/airline-core/src/main/resources/META-INF/services/com.github.rvesse.airline.restrictions.factories.ArgumentsRestrictionFactory
+++ b/airline-core/src/main/resources/META-INF/services/com.github.rvesse.airline.restrictions.factories.ArgumentsRestrictionFactory
@@ -6,3 +6,4 @@ com.github.rvesse.airline.restrictions.factories.PortRestrictionFactory
 com.github.rvesse.airline.restrictions.factories.RangeRestrictionFactory
 com.github.rvesse.airline.restrictions.factories.SimpleRestrictionsFactory
 com.github.rvesse.airline.restrictions.factories.StringRestrictionFactory
+com.github.rvesse.airline.restrictions.factories.RequireFromRestrictionFactory

--- a/airline-core/src/test/java/com/github/rvesse/airline/TestHelp.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/TestHelp.java
@@ -66,6 +66,7 @@ import com.github.rvesse.airline.help.sections.common.VersionSection;
 import com.github.rvesse.airline.model.CommandMetadata;
 import com.github.rvesse.airline.parser.resources.ClasspathLocator;
 import com.github.rvesse.airline.parser.resources.ResourceLocator;
+import com.github.rvesse.airline.restrictions.Unless;
 import com.github.rvesse.airline.restrictions.partial.PartialAnnotated;
 import com.github.rvesse.airline.utils.predicates.parser.CommandFinder;
 
@@ -750,6 +751,59 @@ public class TestHelp {
                 "        --required <requiredOption>\n" +
                 "\n" +
                 "\n");
+        //@formatter:on
+    }
+
+    @Test
+    public void testOptionsRequiredUnless() throws IOException {
+        //@formatter:off
+        CliBuilder<Object> builder = Cli.builder("test")
+                                        .withDescription("Test commandline")
+                                        .withDefaultCommand(Help.class)
+                                        .withCommands(Help.class,
+                                                      Unless.class);
+
+        Cli<Object> parser = builder.build();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Help.help(parser.getMetadata(), Collections.singletonList("unless"), out);
+        assertEquals(new String(out.toByteArray(), utf8),
+                     "NAME\n" +
+                             "        test unless -\n" +
+                             "\n" +
+                             "SYNOPSIS\n" +
+                             "        test unless [ --foo <foo> ] [ --path <path> ] [--] [ <arg>... ]" +
+                             "\n" +
+                             "\n" +
+                             "OPTIONS\n" +
+                             "        --foo <foo>\n" +
+                             "            Foo something?\n" +
+                             "\n" +
+                             "            This option is required unless one of the following environment\n" +
+                             "            variables is set:\n" +
+                             "                FOO\n" +
+                             "                FOO_BAR\n" +
+                             "\n" +
+                             "        --path <path>\n" +
+                             "            Sets the PATH.\n" +
+                             "\n" +
+                             "            This option is required unless the environment variable PATH is\n" +
+                             "            set.\n" +
+                             "\n" +
+                             "\n" +
+                             "        --\n" +
+                             "            This option can be used to separate command-line options from the\n" +
+                             "            list of arguments (useful when arguments might be mistaken for\n" +
+                             "            command-line options)\n" +
+                             "\n" +
+                             "        <arg>\n" +
+                             "            Provides additional arguments.\n" +
+                             "\n" +
+                             "            This option is required unless one of the following environment\n" +
+                             "            variables is set:\n" +
+                             "                ARGS\n" +
+                             "                ARGUMENTS\n" +
+                             "\n");
         //@formatter:on
     }
 

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/TestRequired.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/TestRequired.java
@@ -1,20 +1,19 @@
 /**
  * Copyright (C) 2010-16 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package com.github.rvesse.airline.restrictions;
 
+import com.github.rvesse.airline.parser.errors.ParseArgumentsMissingException;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.github.rvesse.airline.SingleCommand;
@@ -24,7 +23,7 @@ import com.github.rvesse.airline.parser.errors.ParseOptionMissingException;
 
 
 public class TestRequired {
-    
+
     @Test
     public void require_some_good() {
         SingleCommand<Some> parser = TestingUtil.singleCommandParser(Some.class);
@@ -38,13 +37,13 @@ public class TestRequired {
         parser.parse("-a", "test", "-b", "test2", "-c", "test3");
         parser.parse("-a", "test", "-b", "test2", "-c", "test3", "-a", "test4", "-c", "test5");
     }
-    
+
     @Test(expectedExceptions = ParseOptionGroupException.class)
     public void require_some_bad_none() {
         SingleCommand<Some> parser = TestingUtil.singleCommandParser(Some.class);
         parser.parse();
     }
-    
+
     @Test
     public void require_one_good() {
         SingleCommand<One> parser = TestingUtil.singleCommandParser(One.class);
@@ -55,45 +54,45 @@ public class TestRequired {
         parser.parse("-b", "test", "-b", "test2");
         parser.parse("-c", "test", "-c", "test2", "-c", "test3", "-c", "test4", "-c", "test5");
     }
-    
+
     @Test(expectedExceptions = ParseOptionGroupException.class)
     public void require_one_bad_none() {
         SingleCommand<One> parser = TestingUtil.singleCommandParser(One.class);
         parser.parse();
     }
-    
+
     @Test(expectedExceptions = ParseOptionGroupException.class)
     public void require_one_bad_multiple_01() {
         SingleCommand<One> parser = TestingUtil.singleCommandParser(One.class);
         parser.parse("-a", "test", "-b", "test2");
     }
-    
-    
+
+
     @Test(expectedExceptions = ParseOptionGroupException.class)
     public void require_one_bad_multiple_02() {
         SingleCommand<One> parser = TestingUtil.singleCommandParser(One.class);
         parser.parse("-a", "test", "-c", "test2");
     }
-    
-    
+
+
     @Test(expectedExceptions = ParseOptionGroupException.class)
     public void require_one_bad_multiple_03() {
         SingleCommand<One> parser = TestingUtil.singleCommandParser(One.class);
         parser.parse("-b", "test", "-c", "test2");
     }
-    
+
     @Test
     public void required_if_good_unneeded_missing() {
         SingleCommand<If> parser = TestingUtil.singleCommandParser(If.class);
         parser.parse();
     }
-    
+
     @Test
     public void required_if_good_unneeded_present() {
         SingleCommand<If> parser = TestingUtil.singleCommandParser(If.class);
         parser.parse("-b", "test");
     }
-    
+
     @Test
     public void required_if_good_needed() {
         SingleCommand<If> parser = TestingUtil.singleCommandParser(If.class);
@@ -102,13 +101,13 @@ public class TestRequired {
         parser.parse("-a", "test", "--bravo", "test2");
         parser.parse("--alpha", "test", "--bravo", "test2");
     }
-    
+
     @Test(expectedExceptions = ParseOptionMissingException.class)
     public void required_if_bad_needed() {
         SingleCommand<If> parser = TestingUtil.singleCommandParser(If.class);
         parser.parse("-a", "test");
     }
-    
+
     @Test
     public void mutually_exclusive_with_good() {
         SingleCommand<OptionallyOne> parser = TestingUtil.singleCommandParser(OptionallyOne.class);
@@ -119,28 +118,67 @@ public class TestRequired {
         parser.parse("-b", "test", "-b", "test2");
         parser.parse("-c", "test", "-c", "test2", "-c", "test3", "-c", "test4", "-c", "test5");
     }
-    
+
     @Test
     public void mutually_exclusive_with_none() {
         SingleCommand<OptionallyOne> parser = TestingUtil.singleCommandParser(OptionallyOne.class);
         parser.parse();
     }
-    
+
     @Test(expectedExceptions = ParseOptionGroupException.class)
     public void mutually_exclusive_with_multiple_01() {
         SingleCommand<OptionallyOne> parser = TestingUtil.singleCommandParser(OptionallyOne.class);
         parser.parse("-a", "test", "-b", "test2");
     }
-        
+
     @Test(expectedExceptions = ParseOptionGroupException.class)
     public void mutually_exclusive_with_multiple_02() {
         SingleCommand<OptionallyOne> parser = TestingUtil.singleCommandParser(OptionallyOne.class);
         parser.parse("-a", "test", "-c", "test2");
     }
-        
+
     @Test(expectedExceptions = ParseOptionGroupException.class)
     public void mutually_exclusive_with_multiple_03() {
         SingleCommand<OptionallyOne> parser = TestingUtil.singleCommandParser(OptionallyOne.class);
         parser.parse("-b", "test", "-c", "test2");
+    }
+
+    @Test
+    public void required_unless_env_01() {
+        SingleCommand<Unless> parser = TestingUtil.singleCommandParser(Unless.class);
+        Unless cmd = parser.parse("--path", "/bin", "--foo", "test", "some-arg");
+        Assert.assertEquals(cmd.path, "/bin");
+        Assert.assertEquals(cmd.foo, "test");
+        Assert.assertNotNull(cmd.args);
+        Assert.assertEquals(cmd.args.size(), 1);
+        Assert.assertEquals(cmd.args.get(0), "some-arg");
+    }
+
+    @Test
+    public void required_unless_env_02() {
+        SingleCommand<Unless> parser = TestingUtil.singleCommandParser(Unless.class);
+        Unless cmd = parser.parse("--foo", "test", "some-arg");
+        Assert.assertEquals(cmd.path, System.getenv("PATH"));
+        Assert.assertEquals(cmd.foo, "test");
+        Assert.assertNotNull(cmd.args);
+        Assert.assertEquals(cmd.args.size(), 1);
+        Assert.assertEquals(cmd.args.get(0), "some-arg");
+    }
+
+    @Test(expectedExceptions = ParseOptionMissingException.class, expectedExceptionsMessageRegExp = "Required option.*no default values.*FOO, FOO_BAR")
+    public void required_unless_env_03() {
+        SingleCommand<Unless> parser = TestingUtil.singleCommandParser(Unless.class);
+        Unless cmd = parser.parse();
+        Assert.assertEquals(cmd.path, System.getenv("PATH"));
+        Assert.assertEquals(cmd.foo, "test");
+    }
+
+    @Test(expectedExceptions = ParseArgumentsMissingException.class)
+    public void required_unless_env_04() {
+        SingleCommand<Unless> parser = TestingUtil.singleCommandParser(Unless.class);
+        Unless cmd = parser.parse("--foo", "test");
+        Assert.assertEquals(cmd.path, System.getenv("PATH"));
+        Assert.assertEquals(cmd.foo, "test");
+        Assert.assertEquals(cmd.args.size(), 0);
     }
 }

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/TestRequired.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/TestRequired.java
@@ -1,14 +1,17 @@
 /**
  * Copyright (C) 2010-16 the original author or authors.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.github.rvesse.airline.restrictions;
 
@@ -165,20 +168,15 @@ public class TestRequired {
         Assert.assertEquals(cmd.args.get(0), "some-arg");
     }
 
-    @Test(expectedExceptions = ParseOptionMissingException.class, expectedExceptionsMessageRegExp = "Required option.*no default values.*FOO, FOO_BAR")
+    @Test(expectedExceptions = ParseOptionMissingException.class, expectedExceptionsMessageRegExp = "Required option.*is missing.*no default values.*FOO, FOO_BAR")
     public void required_unless_env_03() {
         SingleCommand<Unless> parser = TestingUtil.singleCommandParser(Unless.class);
-        Unless cmd = parser.parse();
-        Assert.assertEquals(cmd.path, System.getenv("PATH"));
-        Assert.assertEquals(cmd.foo, "test");
+        parser.parse("some-arg");
     }
 
-    @Test(expectedExceptions = ParseArgumentsMissingException.class)
+    @Test(expectedExceptions = ParseArgumentsMissingException.class,expectedExceptionsMessageRegExp = "Required arguments.*are missing.*no default values.*ARGS, ARGUMENTS")
     public void required_unless_env_04() {
         SingleCommand<Unless> parser = TestingUtil.singleCommandParser(Unless.class);
-        Unless cmd = parser.parse("--foo", "test");
-        Assert.assertEquals(cmd.path, System.getenv("PATH"));
-        Assert.assertEquals(cmd.foo, "test");
-        Assert.assertEquals(cmd.args.size(), 0);
+        parser.parse("--foo", "test");
     }
 }

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Unless.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Unless.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rvesse.airline.restrictions;
+
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.RequiredUnlessEnvironment;
+import org.apache.commons.lang3.StringUtils;
+
+import java.sql.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Command(name = "unless")
+public class Unless {
+
+    private static String fromEnv(String... vars) {
+        String value = null;
+        for (String var : vars) {
+            value = System.getenv(var);
+            if (StringUtils.isNotBlank(value))
+                break;
+            value = null;
+        }
+        return value;
+    }
+
+    private static List<String> fromEnvAsList(String... vars) {
+        String value = fromEnv(vars);
+        if (StringUtils.isNotBlank(value)) {
+            return Arrays.asList(StringUtils.split(value, ","));
+        }
+        return new ArrayList<>();
+    }
+    
+    @Option(name = "--path")
+    @RequiredUnlessEnvironment(variables = "PATH")
+    public String path = fromEnv("PATH");
+    
+    @Option(name = "--foo")
+    @RequiredUnlessEnvironment(variables = { "FOO", "FOO_BAR" })
+    public String foo = fromEnv("FOO", "FOO_BAR");
+
+    @Arguments(title = "arg")
+    @RequiredUnlessEnvironment(variables = { "ARGS", "ARGUMENTS" })
+    public List<String> args = new ArrayList<>(fromEnvAsList("ARGS", "ARGUMENTS"));
+}

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Unless.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Unless.java
@@ -48,15 +48,15 @@ public class Unless {
         return new ArrayList<>();
     }
     
-    @Option(name = "--path")
+    @Option(name = "--path", description = "Sets the PATH.")
     @RequiredUnlessEnvironment(variables = "PATH")
     public String path = fromEnv("PATH");
     
-    @Option(name = "--foo")
+    @Option(name = "--foo", description = "Foo something?")
     @RequiredUnlessEnvironment(variables = { "FOO", "FOO_BAR" })
     public String foo = fromEnv("FOO", "FOO_BAR");
 
-    @Arguments(title = "arg")
+    @Arguments(title = "arg", description = "Provides additional arguments.")
     @RequiredUnlessEnvironment(variables = { "ARGS", "ARGUMENTS" })
     public List<String> args = new ArrayList<>(fromEnvAsList("ARGS", "ARGUMENTS"));
 }

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -46,6 +46,8 @@
                   <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/require-some.html">@RequireSome</a></li>
                   <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/require-only-one.html">@RequireOnlyOne</a></li>
                   <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/mutually-exclusive-with.html">@MutuallyExclusiveWith</a></li>
+                  <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/required-only-if.html">@RequiredOnlyIf</a></li>
+                  <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/required-unless.html">@RequiredUnless</a></li>
                 </ul>
               </li>
               <li>

--- a/docs/guide/annotations/no-option-like-values.md
+++ b/docs/guide/annotations/no-option-like-values.md
@@ -5,6 +5,8 @@ title: NoOptionLikeValues Annotation
 
 ## `@NoOptionLikeValues`
 
+{% include req-ver.md version="2.8.4" %}
+
 The `@NoOptionLikeValues` annotation can be used to require that values don't look like options. Note that the Airline
 parsers are non-greedy so won't consume values that are clearly options. However, sometimes users may make typos when
 providing options in which case those values would get consumed by other `@Option`/`@Arguments`

--- a/docs/guide/annotations/require-some.md
+++ b/docs/guide/annotations/require-some.md
@@ -1,15 +1,16 @@
 ---
-layout: page
+layout: page 
 title: RequireSome Annotation
 ---
 
 ## `@RequireSome`
 
-The `@RequireSome` annotation is applied to a field annotated with [`@Option`](option.html) to indicate that at least one from some set of options must be specified e.g.
+The `@RequireSome` annotation is applied to a field annotated with [`@Option`](option.html) to indicate that at least
+one from some set of options must be specified e.g.
 
 ```java
-@Option(name = "--num", 
-        arity = 1, 
+@Option(name = "--num",
+        arity = 1,
         title = "Number")
 @RequireSome(tag = "identifier")
 private int number;
@@ -21,12 +22,15 @@ private int number;
 private String name;
 ```
 
-When fields are marked with `@RequireSome` if the user fails to supply at least one of the options that have the same `tag` value then an error will be thrown during [parsing](../parser/).
+When fields are marked with `@RequireSome` if the user fails to supply at least one of the options that have the
+same `tag` value then an error will be thrown during [parsing](../parser/).
 
 In this example the user must specify at least one of the `--num` or `--name` option and may specify both if desired.
 
 ### Related Annotations
 
-If you want to require that at most one of some set of options be specified then you should use [`@RequireOnlyOne`](require-only-one.html) instead.
+If you want to require that at most one of some set of options be specified then you should
+use [`@RequireOnlyOne`](require-only-one.html) instead.
 
-If you optionally want to allow only one from some set of options then you should use [`@MutuallyExclusiveWith`](mutually-exclusive-with.html).
+If you optionally want to allow only one from some set of options then you should
+use [`@MutuallyExclusiveWith`](mutually-exclusive-with.html).

--- a/docs/guide/annotations/required-only-if.md
+++ b/docs/guide/annotations/required-only-if.md
@@ -1,0 +1,34 @@
+---
+layout: page 
+title: Required Only If Annotation
+---
+
+## `@RequiredOnlyIf`
+
+The `@RequiredOnlyIf` annotation is applied to a field annotated with [`@Option`](option.html) or [`@Arguments`]
+(arguments.html) to indicate that the option/argument must be specified only when some other option is specified.  
+This is typically used when you have options that only make sense in conjunction with other options, but are required
+when those options are used.
+
+```java
+@Option(name = "--authenticate",
+        arity = 0,
+        description = "Enables authentication")
+private boolean authenticate = false;
+
+@Option(name = "--user-source",
+        arity = 1,
+        description = "Specifies a source of user information used when authentication is enabled.")
+@RequiredOnlyIf(names = { "--authenticate" })
+private String userSource;
+```
+
+When a field is marked with `@RequiredOnlyIf` and any of the named options are used then this option becomes 
+required.  So in the above example if a user specifies `--authenticate` then they **MUST** also specify `--user-source`.
+
+If the user fails to supply the correct combination of options and arguments then an error will be thrown during
+[parsing](.. /parser/)
+
+### Related Annotations
+
+If you want to require an option regardless then you should use [`@Required`](required.html)

--- a/docs/guide/annotations/required-unless-environment.md
+++ b/docs/guide/annotations/required-unless-environment.md
@@ -1,0 +1,32 @@
+---
+layout: page 
+title: Required Unless Environment Annotation
+---
+
+## `@RequiredUnlessEnvironment`
+
+{% include req-ver.md version="2.8.5" %}
+
+The `@RequiredUnlessEnvironment` annotation is applied to a field annotated with [`@Option`](option.html) or
+[`@Arguments`](arguments.html) to indicate that the option/argument must be specified unless some environment variable
+is specified. This is typically used when your program automatically reads a default setting from the environment but
+allows the user to override it via an option e.g.
+
+```java
+@Option(name = "--server",
+        arity = 1,
+        description = "Specifies the server to connect to.")
+@RequiredUnlessEnvironment(variables = { "MY_SERVER" })
+private String server = System.getenv("MY_SERVER");
+```
+
+When a field is marked with `@RequiredUnlessEnvironment` it only becomes required if none of the specified 
+environment variables are set.  As seen in this example your code remains responsible for populating your 
+option/argument from the environment variable appropriately.
+
+If the user fails to supply the option/argument and no suitable environment variable is set then an error will be thrown
+during [parsing](../parser/)
+
+### Related Annotations
+
+If you want to require an option regardless then you should use [`@Required`](required.html)

--- a/docs/guide/annotations/required.md
+++ b/docs/guide/annotations/required.md
@@ -1,22 +1,24 @@
 ---
-layout: page
+layout: page 
 title: Required Annotation
 ---
 
 ## `@Required`
 
-The `@Required` annotation is applied to a field annotated with [`@Option`](option.html) or [`@Arguments`](arguments.html) to indicate that the option/argument must be specified.
+The `@Required` annotation is applied to a field annotated with [`@Option`](option.html)
+or [`@Arguments`](arguments.html) to indicate that the option/argument must be specified.
 
 ```java
-@Option(name = "--num", 
-        arity = 1, 
+@Option(name = "--num",
+        arity = 1,
         title = "Number")
 @Required
 private int number;
 ```
 
-When a field is marked with `@Required` if the user fails to supply that option/argument then an error will be thrown during [parsing](../parser/)
+When a field is marked with `@Required` if the user fails to supply that option/argument then an error will be thrown
+during [parsing](../parser/)
 
 ### Related Annotations
 
-If you want to require one option from some set of options then you should use [`@RequireSome`](require-some.md)
+If you want to require one option from some set of options then you should use [`@RequireSome`](require-some.html)


### PR DESCRIPTION
Provides a new restriction annotation that makes an `@Option`/`@Argument` annotated field required only if suitable environment variable(s) are not set