### PR TITLE
Only display the help footer if there is a help command

### DIFF
--- a/airline-core/src/main/java/com/github/rvesse/airline/help/cli/CliCommandGroupUsageGenerator.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/cli/CliCommandGroupUsageGenerator.java
@@ -26,9 +26,12 @@ import com.github.rvesse.airline.model.CommandGroupMetadata;
 import com.github.rvesse.airline.model.CommandMetadata;
 import com.github.rvesse.airline.model.GlobalMetadata;
 import com.github.rvesse.airline.model.OptionMetadata;
+import com.github.rvesse.airline.utils.predicates.parser.CommandFinder;
 import static com.github.rvesse.airline.help.UsageHelper.DEFAULT_COMMAND_COMPARATOR;
 import static com.github.rvesse.airline.help.UsageHelper.DEFAULT_OPTION_COMPARATOR;
 import static com.github.rvesse.airline.help.UsageHelper.DEFAULT_HINT_COMPARATOR;
+
+import org.apache.commons.collections4.IterableUtils;
 
 public class CliCommandGroupUsageGenerator<T> extends AbstractPrintedCommandGroupUsageGenerator<T> {
     private final boolean hideGlobalOptions;
@@ -285,9 +288,14 @@ public class CliCommandGroupUsageGenerator<T> extends AbstractPrintedCommandGrou
         if (hasDefaultCommand) {
             synopsis.newline().append("Where * indicates the default command(s)");
         }
-        synopsis.newline().append("See").append("'" + global.getName()).append("help ")
-                .appendWords(UsageHelper.toGroupNames(Arrays.asList(groups)))
-                .appendOnOneLine(" <command>' for more information on a specific command.").newline();
+
+        boolean hasHelpCommand = IterableUtils.find(global.getDefaultGroupCommands(), new CommandFinder("help")) != null;
+
+        if (hasHelpCommand) {
+            synopsis.newline().append("See").append("'" + global.getName()).append("help ")
+                    .appendWords(UsageHelper.toGroupNames(Arrays.asList(groups)))
+                    .appendOnOneLine(" <command>' for more information on a specific command.").newline();
+        }
     }
 
     /**

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/cli/CliGlobalUsageSummaryGenerator.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/cli/CliGlobalUsageSummaryGenerator.java
@@ -24,6 +24,7 @@ import com.github.rvesse.airline.model.CommandGroupMetadata;
 import com.github.rvesse.airline.model.CommandMetadata;
 import com.github.rvesse.airline.model.GlobalMetadata;
 import com.github.rvesse.airline.model.OptionMetadata;
+import com.github.rvesse.airline.utils.predicates.parser.CommandFinder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,6 +33,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+
+import org.apache.commons.collections4.IterableUtils;
 
 public class CliGlobalUsageSummaryGenerator<T> extends AbstractPrintedGlobalUsageGenerator<T> {
     
@@ -107,9 +110,13 @@ public class CliGlobalUsageSummaryGenerator<T> extends AbstractPrintedGlobalUsag
      * @throws IOException
      */
     protected void outputFooter(UsagePrinter out, GlobalMetadata<T> global) throws IOException {
-        out.newline();
-        out.append("See").append("'" + global.getName())
-                .append("help <command>' for more information on a specific command.").newline();
+        boolean hasHelpCommand = IterableUtils.find(global.getDefaultGroupCommands(), new CommandFinder("help")) != null;
+
+        if (hasHelpCommand) {
+            out.newline();
+            out.append("See").append("'" + global.getName())
+                    .append("help <command>' for more information on a specific command.").newline();
+        }
     }
 
     /**

--- a/airline-core/src/test/java/com/github/rvesse/airline/TestHelp.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/TestHelp.java
@@ -1179,7 +1179,8 @@ public class TestHelp {
     @Test
     public void testVersionCli2() throws IOException {
         //@formatter:off
-        Cli<Args1> cli = new CliBuilder<Args1>("test")
+        Cli<Object> cli = new CliBuilder<>("test")
+                            .withCommand(Help.class)
                             .withCommand(Args1.class)
                             .withHelpSection(new VersionSection(new String[] { "/test.version" }, 
                                                                 new ResourceLocator[] { new ClasspathLocator() }, 
@@ -1194,12 +1195,13 @@ public class TestHelp {
                             .build();
     
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        new CliGlobalUsageSummaryGenerator<Args1>().usage(cli.getMetadata(), out);
+        new CliGlobalUsageSummaryGenerator<>().usage(cli.getMetadata(), out);
         testStringAssert(new String(out.toByteArray(), utf8),
                 "usage: test <command> [ <args> ]\n" + 
                 "\n" + 
                 "Commands are:\n" + 
                 "    Args1   args1 description\n" + 
+                "    help    Display help information\n" +
                 "\n" + 
                 "See 'test help <command>' for more information on a specific command.\n" +
                 "\n" +
@@ -1376,6 +1378,49 @@ public class TestHelp {
                 "\n" + 
                 "        Bar\n" +
                 "\n");
+        //@formatter:on
+    }
+
+    @Test
+    public void testHelpWithoutHelpCommand() throws IOException {
+        //@formatter:off
+        CliBuilder<Object> builder = Cli.builder("test")
+                .withDescription("Test commandline")
+                .withCommand(ArgsRequired.class);
+
+        Cli<Object> parser = builder.build();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Help.help(parser.getMetadata(), Collections.<String>emptyList(), out);
+        Assert.assertEquals(new String(out.toByteArray(), utf8),
+                "usage: test <command> [ <args> ]\n" +
+                "\n" +
+                "Commands are:\n" +
+                "    ArgsRequired" +
+                "\n");
+        //@formatter:on
+    }
+
+    @Test
+    public void testHelpWithHelpCommand() throws IOException {
+        //@formatter:off
+        CliBuilder<Object> builder = Cli.builder("test")
+                .withDescription("Test commandline")
+                .withCommand(Help.class)
+                .withCommand(ArgsRequired.class);
+
+        Cli<Object> parser = builder.build();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Help.help(parser.getMetadata(), Collections.<String>emptyList(), out);
+        Assert.assertEquals(new String(out.toByteArray(), utf8),
+                "usage: test <command> [ <args> ]\n"
+                + "\n"
+                + "Commands are:\n"
+                + "    ArgsRequired\n"
+                + "    help           Display help information\n"
+                + "\n"
+                + "See 'test help <command>' for more information on a specific command.\n");
         //@formatter:on
     }
 }

--- a/airline-core/src/test/java/com/github/rvesse/airline/TestSubGroups.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/TestSubGroups.java
@@ -131,6 +131,7 @@ public class TestSubGroups {
         //@formatter:off
         CliBuilder<Object> builder
             = Cli.<Object>builder("test");
+        builder.withCommand(Help.class);
         builder.withGroup("foo")
                .withSubGroup("bar")
                .withDefaultCommand(Help.class);
@@ -145,6 +146,7 @@ public class TestSubGroups {
             "usage: test <command> [ <args> ]",
             "",
             "Commands are:",
+            "    help   Display help information",
             "    foo",
             "",
             "See 'test help <command>' for more information on a specific command.",
@@ -160,6 +162,7 @@ public class TestSubGroups {
         //@formatter:off
         CliBuilder<Object> builder
             = Cli.<Object>builder("test");
+        builder.withCommand(Help.class);
         builder.withGroup("foo")
                .withSubGroup("bar")
                .withDefaultCommand(Help.class);
@@ -190,10 +193,43 @@ public class TestSubGroups {
     }
     
     @Test
+    public void sub_groups_help_02_without_help_command() throws IOException {
+        //@formatter:off
+        CliBuilder<Object> builder
+            = Cli.<Object>builder("test");
+        builder.withGroup("foo")
+               .withSubGroup("bar")
+               .withDefaultCommand(Help.class);
+        //@formatter:on
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Help.help(builder.build().getMetadata(), Arrays.asList(new String[] { "foo", "bar" }), false, output);
+        String actual = new String(output.toByteArray());
+
+        //@formatter:off
+        String expected = StringUtils.join(new String[] {
+            "NAME",
+            "        test foo bar -",
+            "",
+            "SYNOPSIS",
+            "        test foo bar { help* } [--] <cmd-args>",
+            "",
+            "        Where command-specific arguments <cmd-args> are:",
+            "            help: [ <command>... ]",
+            "",
+            "        Where * indicates the default command(s)"
+        }, '\n');
+        //@formatter:on
+
+        Assert.assertEquals(actual, expected);
+    }
+    
+    @Test
     public void sub_groups_help_03() throws IOException {
         //@formatter:off
         CliBuilder<Object> builder
             = Cli.<Object>builder("test");
+        builder.withCommand(Help.class);
         builder.withGroup("foo")
                .withSubGroup("bar")
                .withDefaultCommand(Help.class);


### PR DESCRIPTION
Hey @rvesse,

In my usage of Airline, I display the help when there is a parse error and users of my library might not have always defined a help command so always having the footer present is misleading.

I adjusted the tests that needed a Help command to be OK but other than that, it didn't trigger any weird behavior AFAICS.