### PR TITLE
Transition to jakarta.inject.Inject (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Airline - Change Log
 
-## 2.8.6
+## 2.9.0
 
 - Build Improvements
    - Added GitHub Actions based CI/CD for the repository
@@ -8,9 +8,20 @@
      included in the dependencies of the core `airline` module by default.  Note that future 3.x releases may
      make this dependency optional as the Java ecosystem transitions away from using the old `javax` packages.
 - Annotation Improvements
+   - Added `@AirlineModule` as future replacement for existing usage of `@Inject` 
    - `@Inject` can now be either `javax.inject.Inject` or `jakarta.inject.Inject`, and mixtures thereof are
      supported.  This enables broader compatibility with applications that need/want to use either variant of
-     the `jakarta.inject` dependency.
+     the standard Java `@Inject` dependency.
+- Parser Improvements
+   - Choice of composition annotations is now configurable.  Defaulting to supporting the new `@AirlineModule` 
+     annotation, and for backwards compatibility both variants of the `@Inject` annotation as noted above.
+       - Use `compositionAnnotationClasses` field with the `@Parser` annotation
+       - Use `withCompositionAnnotations()` or `withDefaultCompositionAnnotations()` with the `ParserBuilder`
+
+**NB:** The changes to injection annotations have been carefully done to be fully backwards compatible with existing
+Airline annotations for the 2.9.x releases.  Future minor and major releases will change the default behaviour to 
+**only** support `@AirlineModule`.  Therefore, you may wish to start migrating your applications to using this 
+annotation sooner rather than later.
 
 ## 2.8.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Airline - Change Log
 
+## 2.8.6
+
+- Build Improvements
+   - Added GitHub Actions based CI/CD for the repository
+   - Added a new `airline-backcompact-javaxinject` module to aid Annotation Improvements (see below), this is
+     included in the dependencies of the core `airline` module by default.  Note that future 3.x releases may
+     make this dependency optional as the Java ecosystem transitions away from using the old `javax` packages.
+- Annotation Improvements
+   - `@Inject` can now be either `javax.inject.Inject` or `jakarta.inject.Inject`, and mixtures thereof are
+     supported.  This enables broader compatibility with applications that need/want to use either variant of
+     the `jakarta.inject` dependency.
+
 ## 2.8.5
 
 - Restriction Improvements

--- a/Migrating.md
+++ b/Migrating.md
@@ -1,10 +1,20 @@
+# Migration to Airline 2.9
+
+Airline 2.9 introduces some changes to injection annotations in preparation for breaking changes in future releases.  In
+particular unless you use Airline in conjunction with a dependency injection framework you should stop using the 
+`@Inject` annotation on command fields and transition to using the `@AirlineModule` annotation instead.
+
+For backwards compatibility purposes usage of the older `@Inject` annotation remains supported for the time being 
+**BUT** this will require explicit user configuration in future releases.
+
 # Migration to Airline 2.2 from Airline 2.1
 
 Airline 2.2 has some minor breaking changes versus Airline 2.1
 
 ## `@Arguments` arity
 
-Previously `@Arguments` had an `arity` field that was used to control the maximum arity of arguments.  In 2.2 this is removed and you should use the `@MaxOccurrences` restriction annotation to achieve the same effect e.g.
+Previously `@Arguments` had an `arity` field that was used to control the maximum arity of arguments.  In 2.2 this is 
+removed and you should use the `@MaxOccurrences` restriction annotation to achieve the same effect e.g.
 
 ```java
 @Arguments
@@ -14,11 +24,14 @@ private List<String> args = new ArrayList<>();
 
 ## RONN Help Removed
 
-The `airline-help-ronn` module was removed in 2.2 as it was already deprecated.  For Markdown format help use the `airline-help-markdown` module and for Man pages uses the `airline-help-man` module.
+The `airline-help-ronn` module was removed in 2.2 as it was already deprecated.  For Markdown format help use the 
+`airline-help-markdown` module and for Man pages uses the `airline-help-man` module.
 
 ## Global Restriction Annotations
 
-Previously global restrictions for CLIs could only be specified via the `restrictions` field of the `@Cli` annotation.  As of Airline 2.2 the global restrictions can now be specified via annotations in the same way that option and argument restrictions are specified.
+Previously global restrictions for CLIs could only be specified via the `restrictions` field of the `@Cli` annotation.  
+As of Airline 2.2 the global restrictions can now be specified via annotations in the same way that option and argument 
+restrictions are specified.
 
 Airline 2.2 supports the following global restriction annotations:
 
@@ -27,7 +40,9 @@ Airline 2.2 supports the following global restriction annotations:
 - `@NoMissingOptionValues`
 - `@None`
 
-Note that most users will not need to use these annotations as the `@Cli` annotation has the `includeDefaultRestrictions` field default to `true` which causes the default set of global restrictions to be included without any further user configuration.
+Note that most users will not need to use these annotations as the `@Cli` annotation has the 
+`includeDefaultRestrictions` field default to `true` which causes the default set of global restrictions to be included 
+without any further user configuration.
 
 ---
 
@@ -37,7 +52,8 @@ Airline 2.1 includes a number of breaking changes which are part of improvements
 
 ## Help Modules
 
-Previously all help generators were included in the main `airline` module.  With Airline 2.1 only the CLI help is included in that module, all other help generators are provided by separate modules which can be pulled in as desired.
+Previously all help generators were included in the main `airline` module.  With Airline 2.1 only the CLI help is 
+included in that module, all other help generators are provided by separate modules which can be pulled in as desired.
 
 Help Generators | New Module
 ---------------------- | -----------------
@@ -51,17 +67,25 @@ If you were using any of these then you may need to tweak your dependencies appr
 
 ## Generating Man pages
 
-Previously we provided RONN format help generators which generated RONN output (an extended dialect of Markdown) that could then be converted into `man` pages with the `ronn` tool.  However we found that RONN had a number of bugs that could cause the generated man pages to have strange formatting in some cases.
+Previously we provided RONN format help generators which generated RONN output (an extended dialect of Markdown) that 
+could then be converted into `man` pages with the `ronn` tool.  However we found that RONN had a number of bugs that 
+could cause the generated man pages to have strange formatting in some cases.
 
-To address this new Man format help generators are introduced which are capable of generating man pages directly without needing an intermediate format or third party tool.  As a result the existing RONN generators are deprecated and should be avoided in favour of the new help generators.
+To address this new Man format help generators are introduced which are capable of generating man pages directly without 
+needing an intermediate format or third party tool.  As a result the existing RONN generators are deprecated and should 
+be avoided in favour of the new help generators.
 
 ## Generating Markdown help
 
-Since RONN generators are now deprecated we have also added new Markdown format help generators which can be used to generate Markdown format help directly.  These don't use any of the extended RONN syntax though they do use GitHub Flaboured Markdown table syntax for tables.
+Since RONN generators are now deprecated we have also added new Markdown format help generators which can be used to 
+generate Markdown format help directly.  These don't use any of the extended RONN syntax though they do use GitHub 
+Flavoured Markdown table syntax for tables.
 
 ## Bash Completion
 
-Previously information for Bash completion was provided by the `completionBehaviour` and `completionCommand` fields of the `@Option` and `@Arguments` annotations.  In 2.1 these are now moved into their own `@BashCompletion` annotation which is now found in the `airline-help-bash` module.
+Previously information for Bash completion was provided by the `completionBehaviour` and `completionCommand` fields of 
+the `@Option` and `@Arguments` annotations.  In 2.1 these are now moved into their own `@BashCompletion` annotation 
+which is now found in the `airline-help-bash` module.
 
 For example in Airline 2:
 
@@ -76,20 +100,28 @@ Would change to the following in Airline 2.1:
     
 ## Restriction Factories
 
-In Airline 2.0 restriction factories had to be explicitly registered with the `RestrictionRegistry`, Airline 2.1 moves to using `ServiceLoader` for discovery of restriction factories.  While factories may still be explicitly registered they can now also be specified in the following files:
+In Airline 2.0 restriction factories had to be explicitly registered with the `RestrictionRegistry`, Airline 2.1 moves 
+to using `ServiceLoader` for discovery of restriction factories.  While factories may still be explicitly registered 
+they can now also be specified in the following files:
 
 - `META-INF/services/com.github.rvesse.airline.restrictions.factories.OptionRestrictionFactory` 
 - `META-INF/services/com.github.rvesse.airline.restrictions.factories.ArgumentsRestrictionFactory`
 
-Note that if you want to use this mechanism and intend to use the Maven shade plugin or similar to build a single JAR you must ensure that you preserve the built-in services files from the `airline` module as otherwise the built-in restriction annotations will not be honoured.
+Note that if you want to use this mechanism and intend to use the Maven shade plugin or similar to build a single JAR 
+you must ensure that you preserve the built-in services files from the `airline` module as otherwise the built-in 
+restriction annotations will not be honoured.
 
 ## Help Section Factories
 
-In Airline 2.0 help section factories had to be explicitly registered with the `HelpSectionFactory`, Airline 2.1 moves to using `ServiceLoader` for discovery of help section factories.  While factories may still be explicitly registered they can now also be specified in the following file:
+In Airline 2.0 help section factories had to be explicitly registered with the `HelpSectionFactory`, Airline 2.1 moves 
+to using `ServiceLoader` for discovery of help section factories.  While factories may still be explicitly registered 
+they can now also be specified in the following file:
 
 - `META-INF/services/com.github.rvesse.airline.help.sections.factories.HelpSectionFactory`
 
-Note that if you want to use this mechanism and intend to use the Maven shade plugin or similar to build a single JAR you must ensure that you preserve the built-in services files from the `airline` module as otherwise the built-in help section annotations will not be honoured.
+Note that if you want to use this mechanism and intend to use the Maven shade plugin or similar to build a single JAR 
+you must ensure that you preserve the built-in services files from the `airline` module as otherwise the built-in help 
+section annotations will not be honoured.
 
 Additionally the `HelpSectionRegistry` was moved into the `com.github.rvesse.airline.help.sections.factories` package.
 
@@ -97,13 +129,16 @@ Additionally the `HelpSectionRegistry` was moved into the `com.github.rvesse.air
 
 # Migrating to Airline 2 from Airline 1
 
-Airline 2 is a significant rewrite of Airline and as such there are lots of breaking changes to be aware of.  This document aims to guide you through the user facing changes.
+Airline 2 is a significant rewrite of Airline and as such there are lots of breaking changes to be aware of.  This 
+document aims to guide you through the user facing changes.
 
-Note that if you are developing in the internals of Airline there are lots of other changes which are not covered here since they are not visible to end users.
+Note that if you are developing in the internals of Airline there are lots of other changes which are not covered here 
+since they are not visible to end users.
 
 ## Defining CLIs
 
-The major change in defining CLIs using the `CliBuilder<T>` is that all parser related options are now moved onto a new `ParserBuilder<T>`.  This builder can be accessed via the `withParser()` method.
+The major change in defining CLIs using the `CliBuilder<T>` is that all parser related options are now moved onto a new 
+`ParserBuilder<T>`.  This builder can be accessed via the `withParser()` method.
 
 So for example the following Airline 1 code:
 
@@ -135,11 +170,15 @@ builder.withParser()
           .withOptionAbbreviation();
 ```
 
-You can now also define `GlobalRestriction`s using the `withRestriction()` or `withRestrictions()` methods on your `CliBuilder<T>`.  If you don't define any restrictions a default set that provides backwards behavioural compatibility with Airline 1 is used.  This default set can also be explicitly added by calling `withDefaultRestrictions()` on your builder.
+You can now also define `GlobalRestriction`s using the `withRestriction()` or `withRestrictions()` methods on your 
+`CliBuilder<T>`.  If you don't define any restrictions a default set that provides backwards behavioural compatibility 
+with Airline 1 is used.  This default set can also be explicitly added by calling `withDefaultRestrictions()` on your 
+builder.
 
 ## Defining CLIs via Annotation
 
-Previously CLIs could only be defined via the `CliBuilder<T>`, Airline 2 introduces a new `@Cli`  annotation that can be used to define a CLI via a class annotation.
+Previously CLIs could only be defined via the `CliBuilder<T>`, Airline 2 introduces a new `@Cli`  annotation that can be 
+used to define a CLI via a class annotation.
 
 For example the same example as the above could now be defined like so:
 
@@ -153,11 +192,14 @@ A class annotated in this way can be used to create a `Cli` instance like so:
 
 ## Defining Single Commands
 
-Previously you could not specify parser options when defining single commands, you are now able to pass in a `ParserMetadata<T>` in order to specify parser options for single command parsing.
+Previously you could not specify parser options when defining single commands, you are now able to pass in a 
+`ParserMetadata<T>` in order to specify parser options for single command parsing.
 
-Alternatively you can add the `@Parser` annotation to your class and this will be automatically detected and used unless you pass a `ParserMetadata<T>` explicitly to the `singleCommand()` method.
+Alternatively you can add the `@Parser` annotation to your class and this will be automatically detected and used unless 
+you pass a `ParserMetadata<T>` explicitly to the `singleCommand()` method.
 
-You may now also pass in the `GlobalRestriction`s that should apply, if you don't define any restrictions a default set that provides backwards behavioural compatibility with Airline 1 is used
+You may now also pass in the `GlobalRestriction`s that should apply, if you don't define any restrictions a default set 
+that provides backwards behavioural compatibility with Airline 1 is used
 
 ## Annotation Changes
 
@@ -165,7 +207,8 @@ All annotations are now located in the `com.github.rvesse.airline.annotations` p
 
 ### Command Annotation Changes
 
-Some of the extended help fields are no longer available directly on the `@Command` annotation and instead now have their own specific annotations:
+Some extended help fields are no longer available directly on the `@Command` annotation and instead now have 
+their own specific annotations:
 
 - `examples` moved to `@Examples`
 - `discussion` moved to `@Discussion`
@@ -194,9 +237,13 @@ public class MyCommand {
 
 ### Option Annotation Changes
 
-Some fields of the `@Option` annotation that defined restrictions on options have been removed, namely these are the `required`, `allowedValues` and `ignoreCase` attributes.  Option restrictions are now instead expressed with specific annotations such as `@Required`.
+Some fields of the `@Option` annotation that defined restrictions on options have been removed, namely these are the 
+`required`, `allowedValues` and `ignoreCase` attributes.  Option restrictions are now instead expressed with specific 
+annotations such as `@Required`.
 
-When overriding existing options restrictions are inherited from the parent unless new restriction(s) are defined on the overridden option.  If you simply want to remove all existing restrictions when overriding an option you can add the `@Unrestricted` annotation to the overridden option.
+When overriding existing options restrictions are inherited from the parent unless new restriction(s) are defined on the 
+overridden option.  If you simply want to remove all existing restrictions when overriding an option you can add the 
+`@Unrestricted` annotation to the overridden option.
 
 #### Migrating Required Options
 
@@ -226,7 +273,8 @@ Becomes the following in Airline 2:
 
 #### Arguments Annotation Changes
 
-Similar to `@Option` the `@Arguments` annotation has changed to have the `required` field removed, as with options you can now simply add the `@Required` annotation instead to indicate that arguments are required.
+Similar to `@Option` the `@Arguments` annotation has changed to have the `required` field removed, as with options you 
+can now simply add the `@Required` annotation instead to indicate that arguments are required.
 
 Arguments now allows for applying many different restrictions such as `@AllowedRawValues` to arguments.
 
@@ -238,27 +286,35 @@ All exceptions are now located in the `com.github.rvesse.airline.parser.errors` 
 
 ### GlobalMetadata
 
-The `GlobalMetadata` class is now a generic type i.e. `GlobalMetadata<T>` which provides better type safety but may require changing the type signatures of existing code you have written against Airline 1
+The `GlobalMetadata` class is now a generic type i.e. `GlobalMetadata<T>` which provides better type safety but may 
+require changing the type signatures of existing code you have written against Airline 1
 
-A new `getRestrictions()` method provides access to `GlobalRestriction` instances which represent global restrictions on the CLI.
+A new `getRestrictions()` method provides access to `GlobalRestriction` instances which represent global restrictions on 
+the CLI.
 
 #### Accessing Parser Metadata
 
-Parser settings were previously held directly on `GlobalMetadata`, they are now held in a `ParserMetadata<T>` class which is accessed via the `getParserConfiguration()` method on `GlobalMetadata<T>`
+Parser settings were previously held directly on `GlobalMetadata`, they are now held in a `ParserMetadata<T>` class 
+which is accessed via the `getParserConfiguration()` method on `GlobalMetadata<T>`
 
 ### CommandMetadata
 
-The extended help details are no longer expressed directly as fields but as instances of `HelpSection`.  The `getHelpSections()` method provides access to the extended help sections present for a command.
+The extended help details are no longer expressed directly as fields but as instances of `HelpSection`.  The 
+`getHelpSections()` method provides access to the extended help sections present for a command.
 
 ### OptionMetadata
 
-Restrictions on options such as `required` are no longer expressed directly as fields but as instances of `OptionRestriction`.  The `isRequired()` method on `OptionMetadata` will check if the `IsRequiredRestriction` is present for an option.
+Restrictions on options such as `required` are no longer expressed directly as fields but as instances of 
+`OptionRestriction`.  The `isRequired()` method on `OptionMetadata` will check if the `IsRequiredRestriction` is present 
+for an option.
 
 A `getRestrictions()` method provides access to all the restrictions that are present for an option.
 
 ### ArgumentsMetadata
 
-Restrictions on arguments such as `required` are no longer expressed directly as fields but as instances of `ArgumentsRestriction`.  The `isRequired()` method on `ArgumentsMetadata`will check if the `IsRequiredRestriction` is present for the arguments.
+Restrictions on arguments such as `required` are no longer expressed directly as fields but as instances of 
+`ArgumentsRestriction`.  The `isRequired()` method on `ArgumentsMetadata`will check if the `IsRequiredRestriction` is 
+present for the arguments.
 
 A `getRestrictions()` method provides access to all the restrictions that are present for arguments.
 
@@ -266,7 +322,8 @@ A `getRestrictions()` method provides access to all the restrictions that are pr
 
 A new restrictions framework is introduced which allows much more complex restrictions to be specified and enforced.
 
-A few examples are given in the following table, there are many more new restrictions supported by Airline 2 than just these shown here:
+A few examples are given in the following table, there are many more new restrictions supported by Airline 2 than just 
+these shown here:
 
 | Restriction Class | Applicability | Annotation Class | Restriction |
 | -------------- | ---------------- | -------------- | --------------- |
@@ -275,19 +332,27 @@ A few examples are given in the following table, there are many more new restric
 | `RangeRestriction` | Options and Arguments | `@LongRange`, `@IntegerRange`, `@ShortRange`, `@ByteRange`, `@DoubleRange`, `@FloatRange` | Indicates that the instantiated values for options/arguments must fall within a range of values |
 | `None` | Global, Options and Arguments | `@Unrestricted` | Indicates that no restrictions apply, primarily useful if you need to override restrictions inherited from a parent option |
 
-Option and argument restrictions are automatically discovered by examining the annotations present on fields marked with `@Option` and `@Arguments`.  The `RestrictionRegistry` is used to map annotations into instances of `OptionRestriction` or `ArgumentsRestriction` as appropriate.
+Option and argument restrictions are automatically discovered by examining the annotations present on fields marked with 
+`@Option` and `@Arguments`.  The `RestrictionRegistry` is used to map annotations into instances of `OptionRestriction` 
+or `ArgumentsRestriction` as appropriate.
 
-Global restrictions are defined when you create a `Cli` or `SingleCommand` instance, if you don't define any the default set which provides backwards compatibility with the global restrictions that applied in Airline 1 are used.
+Global restrictions are defined when you create a `Cli` or `SingleCommand` instance, if you don't define any the default 
+set which provides backwards compatibility with the global restrictions that applied in Airline 1 are used.
 
-The `ParseRestrictionViolatedException` serves as the parent exception type for all exceptions pertaining to restriction violations.
+The `ParseRestrictionViolatedException` serves as the parent exception type for all exceptions pertaining to restriction 
+violations.
 
 ### Custom Restrictions
 
 You can create your own custom restrictions by doing the following:
 
-- Create a class that implements `OptionRestriction` and/or `ArgumentsRestriction` and enforces your restriction.  Each restriction interface has a different method signature so a restriction can be implemented that applies to multiple things.
-- Create an annotation that you will use to denote your restriction.  Remember to specify the retention for your annotation as `RUNTIME`
-- Create a class that implements `OptionRestrictionFactory` and/or `ArgumentsRestrictionFactory`. This class does the work of converting your annotation into a restriction instance
+- Create a class that implements `OptionRestriction` and/or `ArgumentsRestriction` and enforces your restriction.  Each 
+  restriction interface has a different method signature so a restriction can be implemented that applies to 
+  multiple things.
+- Create an annotation that you will use to denote your restriction.  Remember to specify the retention for your 
+  annotation as `RUNTIME`
+- Create a class that implements `OptionRestrictionFactory` and/or `ArgumentsRestrictionFactory`. This class does the 
+  work of converting your annotation into a restriction instance
 - Register your restriction:  
   `RestrictionRegistry.addOptionRestriction(MyAnnotation.class, new MyRestrictionFactory());`
 
@@ -295,25 +360,38 @@ You can now apply your annotation to the option/arguments field you want to rest
   
 ## Extended Help
 
-Extended help for commands is now specified via the `HelpSection` interface.  This interface allows for supporting a variety of different extended help formats and the built-in help generators will automatically include discovered help sections in their outputs.
+Extended help for commands is now specified via the `HelpSection` interface.  This interface allows for supporting a 
+variety of different extended help formats and the built-in help generators will automatically include discovered help 
+sections in their outputs.
 
-This interface is itself derived from the more basic `HelpHint` interface.  This interface is typically implemented by other classes that serve some function as well as provided some extended help such as `OptionRestriction` implementations.  Again the built-in help generators will automatically include restrictions which provide help hints when formatting help for options and arguments.
+This interface is itself derived from the more basic `HelpHint` interface.  This interface is typically implemented by 
+other classes that serve some function as well as provided some extended help such as `OptionRestriction` 
+implementations.  Again the built-in help generators will automatically include restrictions which provide help hints 
+when formatting help for options and arguments.
 
-Similar to restrictions extra help sections are automatically discovered by examining the annotations present on classes marked with `@Command`.  The `HelpSectionRegistry` is used to map annotations into instances of `HelpSection`.
+Similar to restrictions extra help sections are automatically discovered by examining the annotations present on classes 
+marked with `@Command`.  The `HelpSectionRegistry` is used to map annotations into instances of `HelpSection`.
 
 ### Help Section Inheritance
 
-Help section annotations are automatically inherited so for example if all your commands have a common set of exit codes you could define these once as an annotation on a super-class and all derives command classes would automatically include that exit code section.  Where annotations for the same section (same section being determined by having the case-insensitive same title) are defined multiple times in the class hierarchy the definition lowest in the hierarchy wins i.e. a derived class can always override help sections inherited from their parents.
+Help section annotations are automatically inherited so for example if all your commands have a common set of exit codes 
+you could define these once as an annotation on a super-class and all derives command classes would automatically 
+include that exit code section.  Where annotations for the same section (same section being determined by having the 
+case-insensitive same title) are defined multiple times in the class hierarchy the definition lowest in the hierarchy 
+wins i.e. a derived class can always override help sections inherited from their parents.
 
-If you are extending an annotated class and want to hide a section that you would normally inherit you can do so by adding the `@HideSection(title = "foo")` annotation where `foo` is the title of the section you wish to hide.
+If you are extending an annotated class and want to hide a section that you would normally inherit you can do so by 
+adding the `@HideSection(title = "foo")` annotation where `foo` is the title of the section you wish to hide.
 
 ### Custom Help Sections
 
 You can create your own custom help section by doing the following:
 
 - Create a class that implements `HelpSection`, you can derive from `BasicSection` to get yourself started
-- Create an annotation that you will use to denote your help section.  Remember to specify the retention for your annotation as `RUNTIME`
-- Create a class that implements `HelpSectionFactory`.  This class does the work of converting your annotation into a `HelpSection` instance
+- Create an annotation that you will use to denote your help section.  Remember to specify the retention for your 
+  annotation as `RUNTIME`
+- Create a class that implements `HelpSectionFactory`.  This class does the work of converting your annotation into a 
+  `HelpSection` instance
 - Register your help section:  
     `HelpSectionRegistry.addFactory(MyAnnotation.class, new MySectionFactory());`
 
@@ -329,23 +407,36 @@ Airline 1 supported only three option parsing styles in the following preference
 * Long GNU GetOpt  i.e. `--name=Foo`
 * Whitespace separated ie. `--name Foo`
 
-In this release option parsing is now separated out into its own extensible `OptionParser` interface that allows you to customise how options are parsed.  You can call `withOptionParser()` or `withOptionParsers()` on your `ParserBuilder<T>` to specify the option parsers to use in your desired preference order.
+In this release option parsing is now separated out into its own extensible `OptionParser` interface that allows you to 
+customise how options are parsed.  You can call `withOptionParser()` or `withOptionParsers()` on your `ParserBuilder<T>` 
+to specify the option parsers to use in your desired preference order.
 
-You can also call `withDefaultOptionParsers()` to start from the default Airline 1 setup and then add your own, or call this after adding your own to use the default setup as your fallback.  If you don't explicitly configure any option parsers then the default Airline 1 setup is used automatically.
+You can also call `withDefaultOptionParsers()` to start from the default Airline 1 setup and then add your own, or call 
+this after adding your own to use the default setup as your fallback.  If you don't explicitly configure any option 
+parsers then the default Airline 1 setup is used automatically.
 
 A couple of other parsing styles are now available but not enabled by default:
 
-* `ListValueOptionParser` - Supports parsing options specified in the form `--name a,b,c` where the values is split on a separator (default `,` but configurable as desired) and passed to the option.  This parser is strict in that it requires users invoking commands to provide list values with the correct number of entries present
-* `MaybePairValueOptionParser` - Supports parsing options of arity 2 where they may be specified either as `--name a=b` or `--name a b` i.e. where the user may specify the values either separated by whitespace or some separator (default `=` but configurable as desired)
+* `ListValueOptionParser` - Supports parsing options specified in the form `--name a,b,c` where the values is split on a 
+  separator (default `,` but configurable as desired) and passed to the option.  This parser is strict in that it 
+  requires users invoking commands to provide list values with the correct number of entries present
+* `MaybePairValueOptionParser` - Supports parsing options of arity 2 where they may be specified either as `--name a=b` 
+  or `--name a b` i.e. where the user may specify the values either separated by whitespace or some separator 
+  (default `=` but configurable as desired)
 
 ### Customisable Type Converters
 
-In Airline 1 how raw string values were converted into the appropriate Java types was fixed, with Airline 2 you can now configure the `TypeConverter` instance to use for this as desired.  This can be set via the `withTypeConverter()` method on your `ParserBuilder<T>` instance.
+In Airline 1 how raw string values were converted into the appropriate Java types was fixed, with Airline 2 you can now 
+configure the `TypeConverter` instance to use for this as desired.  This can be set via the `withTypeConverter()` method 
+on your `ParserBuilder<T>` instance.
 
-Creating a custom `TypeConverter` implementation allows you complete control over how you want to convert raw string values into Java types.
+Creating a custom `TypeConverter` implementation allows you complete control over how you want to convert raw string 
+values into Java types.
 
 ### Alias chaining
 
-In Airline 1 aliases could not refer to other aliases, in Airline 2 this behaviour may be enabled and it permits aliases to reference each other unless a circular reference is generated during alias resolution.
+In Airline 1 aliases could not refer to other aliases, in Airline 2 this behaviour may be enabled and it permits aliases 
+to reference each other unless a circular reference is generated during alias resolution.
 
-To enable this you can call `withAliasesChaining()` on a `ParserBuilder<T>` or create an appropriate `ParserMetadata<T>` instance yourself with the appropriate parameter set to `true`.
+To enable this you can call `withAliasesChaining()` on a `ParserBuilder<T>` or create an appropriate `ParserMetadata<T>` 
+instance yourself with the appropriate parameter set to `true`.

--- a/README.md
+++ b/README.md
@@ -9,33 +9,42 @@ Additionally it provides many powerful features including, but not limited to, t
 - Highly customisable [Parser](http://rvesse.github.io/airline/guide/parser/)
 - [User Defined Aliases](http://rvesse.github.io/airline/guide/practise/aliases.html)
 - Annotation driven [restrictions](http://rvesse.github.io/airline/guide/restrictions/) framework to reduce boilerplate
-- Extensible [Help](http://rvesse.github.io/airline/guide/help) system supporting multiple output formats including generating Man pages and Bash completion scripts
-- [Maven Plugin](http://rvesse.github.io/airline/guide/practise/maven-plugin.html) for validation and help generation during builds
+- Extensible [Help](http://rvesse.github.io/airline/guide/help) system supporting multiple output formats including 
+- generating Man pages and Bash completion scripts
+- [Maven Plugin](http://rvesse.github.io/airline/guide/practise/maven-plugin.html) for validation and help generation 
+- during builds
 
 ## User Guide
 
-Our project website at [http://rvesse.github.io/airline/](http://rvesse.github.io/airline/) contains a fairly comprehensive user guide.  Some portions are still under development but it covers the vast majority of the features of the library.
+Our project website at [http://rvesse.github.io/airline/](http://rvesse.github.io/airline/) contains a fairly 
+comprehensive user guide.  Some portions are still under development but it covers the vast majority of the features 
+of the library.
 
 ## Usage
 
-To use airline you need to add a dependency to it to your own code, the Maven artifacts are described later in this ReadMe.
+To use airline you need to add a dependency to it to your own code, the Maven artifacts are described later in this 
+ReadMe.
 
 You then need to use the various annotations to annotate your command classes:
 
 - `@Command` is used to annotate classes
 - `@Option` is used to annotate fields to indicate they are options
 - `@Arguments` is used to annotate fields that take in arguments
-- `@Inject` can be used to modularise option definitions into separate classes
+- `@AirlineModule` can be used to [modularise](http://rvesse.github.io/airline/guide/practise/oop.html) option 
+  definitions into separate classes
 
-Please see the [examples](airline-examples/) module for a range of examples that show off the many features of this library and practical examples of using the annotations.
+Please see the [examples](airline-examples/) module for a range of examples that show off the many features of this 
+library and practical examples of using the annotations.
 
-Or for a quick tutorial why not read our [Introduction to Airline](http://rvesse.github.io/airline/guide/) in our User Guide.
+Or for a quick tutorial why not read our [Introduction to Airline](http://rvesse.github.io/airline/guide/) in our User 
+Guide.
 
 ### Quick Examples
 
 #### Single Commands
 
-Simply create a parser instance via `SingleCommand.singleCommand()` passing in a class that is annotated with the `@Command` annotation e.g.
+Simply create a parser instance via `SingleCommand.singleCommand()` passing in a class that is annotated with the 
+`@Command` annotation e.g.
 
 ```java
     public static void main(String[] args) {
@@ -49,18 +58,23 @@ Simply create a parser instance via `SingleCommand.singleCommand()` passing in a
 
 #### Multiple Commands
 
-Create an instance of a `Cli`, this can be done either using the `CliBuilder` or by annotating a class with the `@Cli` annotation.  This is somewhat more involved so please see the [User Guide](http://rvesse.github.io/airline/guide/#building-a-cli) or the [examples module](examples/) for proper examples.
+Create an instance of a `Cli`, this can be done either using the `CliBuilder` or by annotating a class with the `@Cli` 
+annotation.  This is somewhat more involved so please see the
+[User Guide](http://rvesse.github.io/airline/guide/#building-a-cli) or the [examples module](examples/) for proper 
+examples.
 
 #### Executable JAR
 
-Note that typically you will want to create an executable JAR for your CLI using something like the Maven Shade plugin.  This will then allow you to create a simple wrapper script that invokes your CLI.
+Note that typically you will want to create an executable JAR for your CLI using something like the Maven Shade plugin.  
+This will then allow you to create a simple wrapper script that invokes your CLI.
 
     #!/bin/bash
     # myapp
     
     java -jar my-app.jar "$@"
     
-**Note:** You must use `"$@"` here as otherwise Bash may expand/interpret arguments and as a result the JVM may not receive the expected arguments that the user enters.
+**Note:** You must use `"$@"` here as otherwise Bash may expand/interpret arguments and as a result the JVM may not 
+receive the expected arguments that the user enters.
 
 If this is done you can then invoke your application e.g.
 
@@ -85,11 +99,17 @@ Our source code is Java 7 compliant.
 
 ### Build
 
-Airline can be built with Java 7 through 11 and our `pom.xml` contains appropriate profile customisations to enable this.  Regardless of the version built the `pom.xml` will target Java 7 byte code.  Our official releases are built with Java 8 but targeting Java 7 bytecode to maximise version compatibility.
+Airline can be built with Java 7 through 11 and our `pom.xml` contains appropriate profile customisations to enable this.  
+Regardless of the version built the `pom.xml` will target Java 7 byte code.  Our official releases are built with 
+Java 11 but targeting Java 7 bytecode to maximise version compatibility.
 
-It may be possible to build with newer Java versions than those stated here but those have not been tested by the developers.
+It may be possible to build with newer Java versions than those stated here but those have not been tested by the 
+developers.
 
-**NB** - If you are trying to build older versions from source the relevant `pom.xml` customisations may not have existed at that time.  Also you may encounter SSL errors trying to download Maven plugins using older versions of Java, you may need to first build with a newer version of Java to successfully download relevant Maven plugins before then building with the desired version of Java.
+**NB** - If you are trying to build older versions from source the relevant `pom.xml` customisations may not have 
+existed at that time.  Also. you may encounter SSL errors trying to download Maven plugins using older versions of 
+Java, you may need to first build with a newer version of Java to successfully download relevant Maven plugins before 
+then building with the desired version of Java.
 
 ### Runtime
 
@@ -97,9 +117,12 @@ Airline releases are configured to build Java 7 compatible bytecode so can be us
 
 #### JPMS
 
-Airline does make heavy use of reflection and therefore will likely not work on the Module Path without exporting packages that contain your CLI and Command classes as part of your `module-info.java`
+Airline does make heavy use of reflection and therefore will likely not work on the Module Path without exporting 
+packages that contain your CLI and Command classes as part of your `module-info.java`
 
-From 2.7.0 onwards builds include contributions from our user community to enable use of Airline on the Module Path including relevant `module-info.java` files.  If you encounter a problem with this please report it at https://github.com/rvesse/airline/issues
+From 2.7.0 onwards builds include contributions from our user community to enable use of Airline on the Module Path 
+including relevant `module-info.java` files.  If you encounter a problem with this please report it at 
+https://github.com/rvesse/airline/issues
 
 ## Maven Artifacts
 
@@ -115,20 +138,33 @@ Use the following maven dependency declaration:
 </dependency>
 ```
 
-Snapshot artifacts of the latest source are also available using the version `2.8.6-SNAPSHOT` from the [OSSRH repositories](http://central.sonatype.org/pages/ossrh-guide.html#ossrh-usage-notes).
+Snapshot artifacts of the latest source are also available using the version `2.9.0-SNAPSHOT` from the 
+[OSSRH repositories](http://central.sonatype.org/pages/ossrh-guide.html#ossrh-usage-notes).
 
 ## Build Status
 
-CI builds are run on [Travis CI](http://travis-ci.org/) ![Build Status](https://travis-ci.org/rvesse/airline.png), see build information and history at https://travis-ci.org/rvesse/airline
+CI builds are run on [Travis CI](http://travis-ci.org/) ![Build Status](https://travis-ci.org/rvesse/airline.png), see 
+build information and history at https://travis-ci.org/rvesse/airline
 
 # Historical Information
 
-This is a substantially rewritten fork of the original [airline library](https://github.com/airlift/airline) created based on improvements predominantly developed by myself plus some minor improvements taken from the [Clark & Parsia](https://github.com/clarkparsia/airline) fork.  It has significantly deviated from the original library and gained many powerful features that differentiate it from both the original and other libraries with similar goals.
+This is a substantially rewritten fork of the original [airline library](https://github.com/airlift/airline) created 
+based on improvements predominantly developed by myself plus some minor improvements taken from the
+[Clark & Parsia](https://github.com/clarkparsia/airline) fork.  It has significantly deviated from the original library 
+and gained many powerful features that differentiate it from both the original and other libraries with similar goals.
 
-## Breaking Changes versus 1.x
+## Migrating between Versions
 
-Airline 2 contains significant breaking changes from Airline 1.x, please see [Migrating.md](Migrating.md) for more details on how to migrate code forward.
+Airline 2 contains significant breaking changes from Airline 1.x, please see [Migrating.md](Migrating.md) for more 
+details on how to migrate code forward.
 
-Airline 2.1 contains some further minor breaking changes that should only affect advanced users, again please see [Migrating.md](Migrating.md) for more details on how to migrate code forward.  Some users may need to add additional Maven dependencies if they were using help formats other than the basic CLI help.
+Airline 2.1 contains some further minor breaking changes that should only affect advanced users, again please see 
+[Migrating.md](Migrating.md) for more details on how to migrate code forward.  Some users may need to add additional 
+Maven dependencies if they were using help formats other than the basic CLI help.
 
-Airline 2.2 has some minor breaking changes that may affect users of the `@Arguments` annotation, again please see [Migrating.md](Migrating.md) for more details.
+Airline 2.2 has some minor breaking changes that may affect users of the `@Arguments` annotation, again please see 
+[Migrating.md](Migrating.md) for more details.
+
+Airline 2.9 has some changes to composition in preparation for future breaking changes, most notably introducing the 
+`@AirlineModule` annotation as a replacement for `@Inject`.  It remains backwards compatible with prior 2.x releases 
+but users may wish to start making changes to ease future transitions.

--- a/airline-backcompat-javaxinject/pom.xml
+++ b/airline-backcompat-javaxinject/pom.xml
@@ -11,8 +11,8 @@
     <artifactId>airline-backcompat-javaxinject</artifactId>
 
     <name>Airline - Backwards Compatibility - javax.inject</name>
-    <description>Provides a repackaging of the old jakarta.inject dependency that uses the old javax.inject package
-        under different Maven coordinates so that the old and new @Inject annotations can co-exist within a project.
+    <description>Provides a pointer to the old javax.inject dependency. This is an intentional level of indirection
+        within the dependency tree to make it clear that this dependency is only needed for backwards compatibility.
     </description>
 
     <properties>
@@ -22,28 +22,10 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-            <version>1.0.5</version>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${plugin.shade}</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/airline-backcompat-javaxinject/pom.xml
+++ b/airline-backcompat-javaxinject/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>airline-parent</artifactId>
         <groupId>com.github.rvesse</groupId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>airline-backcompat-javaxinject</artifactId>

--- a/airline-backcompat-javaxinject/pom.xml
+++ b/airline-backcompat-javaxinject/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>airline-parent</artifactId>
+        <groupId>com.github.rvesse</groupId>
+        <version>2.8.6-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>airline-backcompat-javaxinject</artifactId>
+
+    <name>Airline - Backwards Compatibility - javax.inject</name>
+    <description>Provides a repackaging of the old jakarta.inject dependency that uses the old javax.inject package
+        under different Maven coordinates so that the old and new @Inject annotations can co-exist within a project.
+    </description>
+
+    <properties>
+        <license.header.path>${project.parent.basedir}</license.header.path>
+        <coveralls.skip>true</coveralls.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>1.0.5</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${plugin.shade}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/airline-core/pom.xml
+++ b/airline-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.rvesse</groupId>
     <artifactId>airline-parent</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/airline-core/pom.xml
+++ b/airline-core/pom.xml
@@ -28,6 +28,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.rvesse</groupId>
+      <artifactId>airline-backcompat-javaxinject</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>jakarta.inject</groupId>
       <artifactId>jakarta.inject-api</artifactId>
     </dependency>

--- a/airline-core/pom.xml
+++ b/airline-core/pom.xml
@@ -49,6 +49,13 @@
       <artifactId>testng</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/airline-core/pom.xml
+++ b/airline-core/pom.xml
@@ -49,13 +49,6 @@
       <artifactId>testng</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>1</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/airline-core/src/main/java/com/github/rvesse/airline/HelpOption.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/HelpOption.java
@@ -15,12 +15,7 @@
  */
 package com.github.rvesse.airline;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import jakarta.inject.Inject;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.help.CommandUsageGenerator;
 import com.github.rvesse.airline.help.UsageHelper;
@@ -31,19 +26,23 @@ import com.github.rvesse.airline.model.GlobalMetadata;
 import com.github.rvesse.airline.parser.ParseResult;
 import com.github.rvesse.airline.parser.errors.ParseException;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * An option that provides a simple way for the user to request help with a
  * command
  *
  */
 public class HelpOption<C> {
-    @Inject
+    @AirlineModule
     private GlobalMetadata<C> globalMetadata;
 
-    @Inject
+    @AirlineModule
     private CommandGroupMetadata groupMetadata;
 
-    @Inject
+    @AirlineModule
     private CommandMetadata commandMetadata;
 
     @Option(name = { "-h", "--help" }, description = "Display help information")
@@ -62,7 +61,7 @@ public class HelpOption<C> {
     }
 
     /**
-     * Shows help if user requested it and it hasn't already been shown
+     * Shows help if user requested it, and it hasn't already been shown
      * 
      * @param generator
      *            Usage generator

--- a/airline-core/src/main/java/com/github/rvesse/airline/HelpOption.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/HelpOption.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.help.CommandUsageGenerator;

--- a/airline-core/src/main/java/com/github/rvesse/airline/SingleCommand.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/SingleCommand.java
@@ -77,7 +77,7 @@ public class SingleCommand<C> {
         // Dynamically obtain restrictions if annotated onto the class
         this.restrictions = createRestrictions(command, restrictions);
 
-        commandMetadata = MetadataLoader.loadCommand(command);
+        commandMetadata = MetadataLoader.loadCommand(command, this.parserConfig);
     }
     
     private List<GlobalRestriction> createRestrictions(Class<C> commandClass, Iterable<GlobalRestriction> restrictions) {

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/AirlineModule.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/AirlineModule.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2010-16 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.rvesse.airline.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Used to mark a field of a command class as representing a module of command functionality.  For fields marked with
+ * this annotation Airline will inspect their value type in order to find further {@link Option} or {@link Arguments}
+ * annotations that may be present on its fields.  This allows composing common functionality into commands without
+ * using inheritance.  See <a href="http://rvesse.github.io/airline/guide/practise/oop.html">Inheritance and
+ * Composition</a> in the User Guide for more details.
+ * <p>
+ * Historically Airline used the {@code @Inject} annotation for this purpose.  However in recent years dependency
+ * injection has become much more widely used and {@code @Inject} is the standard annotation for that, this often
+ * creates conflicts between Airline and the dependency injection frameworks.  Therefore from <strong>2.9.0</strong>
+ * onwards we introduced this annotation as a replacement for it.
+ * </p>
+ * <p>
+ * For backwards compatibility users can continue to use the {@code @Inject} annotation for the time being
+ * <strong>BUT</strong> this will stop being the default behaviour in future releases and require manual configuration
+ * to achieve.  See {@link Parser#compositionAnnotationClasses()} for how to configure this.
+ * </p>
+ */
+@Target(FIELD)
+@Retention(RUNTIME)
+@Documented
+public @interface AirlineModule {
+}

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/Parser.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/Parser.java
@@ -18,6 +18,7 @@ package com.github.rvesse.airline.annotations;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -38,19 +39,16 @@ import com.github.rvesse.airline.types.numerics.NumericTypeConverter;
 /**
  * Class annotation used to declaratively specify a parser configuration
  * <p>
- * When applied to a class that is also annotated with the {@link Command}
- * annotation then if that class is used with
- * {@link SingleCommand#singleCommand(Class)} the parser configuration will
- * automatically be detected from this annotation.
+ * When applied to a class that is also annotated with the {@link Command} annotation then if that class is used with
+ * {@link SingleCommand#singleCommand(Class)} the parser configuration will automatically be detected from this
+ * annotation.
  * </p>
  * <p>
- * When specifying a CLI via the {@link Cli} annotation then this annotation may
- * be included as an argument to the {@link Cli#parserConfiguration()} field to
- * provide a parser configuration for the CLI.
+ * When specifying a CLI via the {@link Cli} annotation then this annotation may be included as an argument to the
+ * {@link Cli#parserConfiguration()} field to provide a parser configuration for the CLI.
  * </p>
- * 
- * @author rvesse
  *
+ * @author rvesse
  */
 @Target(TYPE)
 @Retention(RUNTIME)
@@ -58,85 +56,79 @@ import com.github.rvesse.airline.types.numerics.NumericTypeConverter;
 public @interface Parser {
 
     /**
-     * Controls whether command names may be abbreviated provided such
-     * abbreviations are unambiguous (default false)
-     * 
+     * Controls whether command names may be abbreviated provided such abbreviations are unambiguous (default false)
+     *
      * @return True if command abbreviation allowed, false otherwise
      */
     boolean allowCommandAbbreviation() default false;
 
     /**
-     * Controls whether options names may be abbreviated provided such
-     * abbreviations are unambiguous (default false)
-     * 
+     * Controls whether options names may be abbreviated provided such abbreviations are unambiguous (default false)
+     *
      * @return True if option abbreviation allowed, false otherwise
      */
     boolean allowOptionAbbreviation() default false;
 
     /**
-     * Controls the separator that is used to distinguish options from arguments
-     * were arguments may be confused as options
+     * Controls the separator that is used to distinguish options from arguments were arguments may be confused as
+     * options
      * <p>
      * The default is {@code --} which is the widely used convention
      * </p>
-     * 
+     *
      * @return Arguments separator
      */
     String argumentsSeparator() default ParserMetadata.DEFAULT_ARGUMENTS_SEPARATOR;
 
     /**
-     * Controls whether command alises may be chained i.e. can aliases be
-     * defined in terms of other aliases (default false)
+     * Controls whether command alises may be chained i.e. can aliases be defined in terms of other aliases (default
+     * false)
      * <p>
      * Note that even when enabled circular references are not permitted
      * </p>
-     * 
+     *
      * @return True if aliases may be chained, false otherwise
      */
     boolean aliasesMayChain() default false;
 
     /**
-     * Controls whether aliases are allowed to override built-in commands i.e.
-     * if a command and an alias are defined with the same name does the alias
-     * take precedence (default false)
+     * Controls whether aliases are allowed to override built-in commands i.e. if a command and an alias are defined
+     * with the same name does the alias take precedence (default false)
      * <p>
-     * This is particularly important if you allow users to define aliases since
-     * allowing overriding would allow them to change the behaviour from the
-     * default expected
+     * This is particularly important if you allow users to define aliases since allowing overriding would allow them to
+     * change the behaviour from the default expected
      * </p>
-     * 
+     *
      * @return True if aliases may override built-ins, false otherwise
      */
     boolean aliasesOverrideBuiltIns() default false;
 
     /**
      * Defines command aliases
-     * 
+     *
      * @return Command aliases
      */
     Alias[] aliases() default {};
 
     /**
-     * Defines the name of a file from which user defined command aliases should
-     * be read
-     * 
+     * Defines the name of a file from which user defined command aliases should be read
+     *
      * @return User aliases filename
      */
     String userAliasesFile() default "";
 
     /**
-     * Defines the search locations (i.e. directories) where the properties file
-     * containing the user defined aliases may exist
+     * Defines the search locations (i.e. directories) where the properties file containing the user defined aliases may
+     * exist
      * <p>
-     * These should be given in order of preference, properties from all
-     * locations will be merged together such that properties from the locations
-     * earlier in this list take precedence
+     * These should be given in order of preference, properties from all locations will be merged together such that
+     * properties from the locations earlier in this list take precedence
      * </p>
      * <p>
-     * Search locations may start with {@code ~/} or {@code ~\} (depending on
-     * the target platform) to refer to the home directory
+     * Search locations may start with {@code ~/} or {@code ~\} (depending on the target platform) to refer to the home
+     * directory
      * </p>
-     * 
+     *
      * @return Search locations for alises
      */
     String[] userAliasesSearchLocation() default "";
@@ -144,72 +136,68 @@ public @interface Parser {
     /**
      * Sets the prefix used for properties that define aliases
      * <p>
-     * This is useful if you use the same properties file to store general
-     * properties for your application in the same properties file. If set only
-     * properties whose names begin with these prefix are treated as alias
-     * definition with the prefix being stripped. So for example if you have a
-     * prefix of {@code foo.} and defined a property {@code foo.bar} then you
-     * would be defining an alias {@code bar}
+     * This is useful if you use the same properties file to store general properties for your application in the same
+     * properties file. If set only properties whose names begin with these prefix are treated as alias definition with
+     * the prefix being stripped. So for example if you have a prefix of {@code foo.} and defined a property
+     * {@code foo.bar} then you would be defining an alias {@code bar}
      * </p>
-     * 
+     *
      * @return User defined aliases prefix
      */
     String userAliasesPrefix() default "";
 
     /**
-     * Sets a character used in alias definitions to indicate that the built-in
-     * should be called regardless of the setting of
-     * {@link #aliasesOverrideBuiltIns()}
+     * Sets a character used in alias definitions to indicate that the built-in should be called regardless of the
+     * setting of {@link #aliasesOverrideBuiltIns()}
      * <p>
-     * This is useful since it allows users to redefine built-ins with their
-     * desired default arguments while still allowing the alias to call the
-     * original built-in. This defaults to {@code !}
+     * This is useful since it allows users to redefine built-ins with their desired default arguments while still
+     * allowing the alias to call the original built-in. This defaults to {@code !}
      * </p>
-     * 
+     *
      * @return Aliases force built-in prefix character
      */
     char aliasesForceBuiltInPrefix() default '!';
 
     /**
      * Sets whether to use the default user alias locators (default true)
-     * 
+     *
      * @return True if defaults are used, false otherwise
      */
     boolean useDefaultAliasLocators() default true;
 
     /**
-     * Sets whether to use the default alias locators first before any
-     * additional alias locators that may be defined (default false)
-     * 
+     * Sets whether to use the default alias locators first before any additional alias locators that may be defined
+     * (default false)
+     *
      * @return True if defaults are used first, false otherwise
      */
     boolean defaultAliasLocatorsFirst() default false;
 
     /**
      * Sets the user alias locator classes to be used
-     * 
+     *
      * @return User alias locator classes
      */
     Class<? extends ResourceLocator>[] userAliasLocators() default {};
 
     /**
      * Sets whether to use the default set of option parsers (default true)
-     * 
+     *
      * @return True if default option parsers are used, false otherwise
      */
     boolean useDefaultOptionParsers() default true;
 
     /**
-     * Sets whether to use the default option parsers first before any
-     * additional option parsers that may be defined (default true)
-     * 
+     * Sets whether to use the default option parsers first before any additional option parsers that may be defined
+     * (default true)
+     *
      * @return True if default parsers are used first, false otherwise
      */
     boolean defaultParsersFirst() default true;
 
     /**
      * Sets the option parser classes to be used
-     * 
+     *
      * @return Option parser classes
      */
     @SuppressWarnings("rawtypes")
@@ -217,32 +205,47 @@ public @interface Parser {
 
     /**
      * Sets the command factory class to use
-     * 
+     *
      * @return Command factory class
      */
     @SuppressWarnings("rawtypes")
     Class<? extends CommandFactory> commandFactory() default DefaultCommandFactory.class;
 
     /**
+     * Sets the injection annotation classes to use
+     * <p>
+     * This is set by providing the fully qualified names of the classes, rather than class references themselves, this
+     * allows Airline to dynamically load the annotation at the point where it collects metadata for classes.  Thus
+     * allowing the actual annotation types used to themselves be injected at runtime rather than compile time.
+     * </p>
+     * <p>
+     * See {@link com.github.rvesse.airline.model.MetadataLoader#loadInjectionMetadata(Class, ParserMetadata)} for more
+     * detailed description of how this configuration is used.
+     * </p>
+     *
+     * @return Injection annotation classes
+     */
+    String[] injectionAnnotationClasses() default {};
+
+    /**
      * Sets the type converter class to use
-     * 
+     *
      * @return Type converter class
      */
     Class<? extends TypeConverter> typeConverter() default DefaultTypeConverter.class;
 
     /**
-     * Sets the numeric type converter to use, this is used in conjunction with
-     * the value of the {@link #typeConverter()}, if that class does not respect
-     * {@link NumericTypeConverter} instances then this field has no effect
-     * 
+     * Sets the numeric type converter to use, this is used in conjunction with the value of the
+     * {@link #typeConverter()}, if that class does not respect {@link NumericTypeConverter} instances then this field
+     * has no effect
+     *
      * @return Numeric type converter class
      */
     Class<? extends NumericTypeConverter> numericTypeConverter() default DefaultNumericConverter.class;
 
     /**
-     * Sets the error handler to use, defaults to {@code FailFast} which throws
-     * errors as soon as they are encountered
-     * 
+     * Sets the error handler to use, defaults to {@code FailFast} which throws errors as soon as they are encountered
+     *
      * @return Error handler to use
      */
     Class<? extends ParserErrorHandler> errorHandler() default FailFast.class;
@@ -250,14 +253,12 @@ public @interface Parser {
     /**
      * Sets the flag negation prefix
      * <p>
-     * If set flag options (those with arity zero) will have their value set to
-     * {@code false} if the name used starts with this prefix. For example if
-     * the prefix is set to {@code --no-} and the user specifies a flag that
-     * begins with this the option will be set to {@code false}. Note that an
-     * appropriate name must be present in the {@link Option#name()} for the
-     * flag option which you wish to allow to be negated.
+     * If set flag options (those with arity zero) will have their value set to {@code false} if the name used starts
+     * with this prefix. For example if the prefix is set to {@code --no-} and the user specifies a flag that begins
+     * with this the option will be set to {@code false}. Note that an appropriate name must be present in the
+     * {@link Option#name()} for the flag option which you wish to allow to be negated.
      * </p>
-     * 
+     *
      * @return Flag negation prefix
      */
     String flagNegationPrefix() default "";

--- a/airline-core/src/main/java/com/github/rvesse/airline/annotations/Parser.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/annotations/Parser.java
@@ -18,7 +18,6 @@ package com.github.rvesse.airline.annotations;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -212,7 +211,7 @@ public @interface Parser {
     Class<? extends CommandFactory> commandFactory() default DefaultCommandFactory.class;
 
     /**
-     * Sets the injection annotation classes to use
+     * Sets the composition annotation classes to use.
      * <p>
      * This is set by providing the fully qualified names of the classes, rather than class references themselves, this
      * allows Airline to dynamically load the annotation at the point where it collects metadata for classes.  Thus
@@ -222,10 +221,16 @@ public @interface Parser {
      * See {@link com.github.rvesse.airline.model.MetadataLoader#loadInjectionMetadata(Class, ParserMetadata)} for more
      * detailed description of how this configuration is used.
      * </p>
+     * <p>
+     * This configuration point was introduced in <strong>2.9.0</strong> as part of the introduction of the
+     * {@link AirlineModule} annotation to provide for backwards compatibility and for users to better integrate with
+     * their chosen dependency injection framework.
+     * </p>
      *
-     * @return Injection annotation classes
+     * @return Composition annotation classes
+     * @since 2.9.0
      */
-    String[] injectionAnnotationClasses() default {};
+    String[] compositionAnnotationClasses() default {};
 
     /**
      * Sets the type converter class to use

--- a/airline-core/src/main/java/com/github/rvesse/airline/builder/CliBuilder.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/builder/CliBuilder.java
@@ -25,15 +25,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Queue;
 
+import com.github.rvesse.airline.model.*;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.collections4.ListUtils;
 
 import com.github.rvesse.airline.Cli;
 import com.github.rvesse.airline.help.sections.HelpSection;
-import com.github.rvesse.airline.model.CommandGroupMetadata;
-import com.github.rvesse.airline.model.CommandMetadata;
-import com.github.rvesse.airline.model.GlobalMetadata;
-import com.github.rvesse.airline.model.MetadataLoader;
 import com.github.rvesse.airline.restrictions.GlobalRestriction;
 import com.github.rvesse.airline.restrictions.None;
 
@@ -153,14 +150,17 @@ public class CliBuilder<C> extends AbstractBuilder<Cli<C>> {
 
     @Override
     public Cli<C> build() {
+        // Need Parser Configuration available up front
+        ParserMetadata<C> parserConfig = this.parserBuilder.build();
+
         CommandMetadata defaultCommandMetadata = null;
         List<CommandMetadata> allCommands = new ArrayList<CommandMetadata>();
         if (defaultCommand != null) {
-            defaultCommandMetadata = MetadataLoader.loadCommand(defaultCommand, baseHelpSections);
+            defaultCommandMetadata = MetadataLoader.loadCommand(defaultCommand, baseHelpSections, parserConfig);
         }
 
         List<CommandMetadata> defaultCommandGroup = defaultCommandGroupCommands != null
-                ? MetadataLoader.loadCommands(defaultCommandGroupCommands, baseHelpSections)
+                ? MetadataLoader.loadCommands(defaultCommandGroupCommands, baseHelpSections, parserConfig)
                 : new ArrayList<CommandMetadata>();
 
         allCommands.addAll(defaultCommandGroup);
@@ -202,7 +202,7 @@ public class CliBuilder<C> extends AbstractBuilder<Cli<C>> {
         // rather than change the entire way metadata is loaded, I figured just
         // post-processing was an easier, yet uglier, way to go
         MetadataLoader.loadCommandsIntoGroupsByAnnotation(allCommands, commandGroups, defaultCommandGroup,
-                baseHelpSections);
+                baseHelpSections, parserConfig);
 
         // Build restrictions
         // Use defaults if none specified
@@ -214,9 +214,9 @@ public class CliBuilder<C> extends AbstractBuilder<Cli<C>> {
 
         // Build metadata objects
         GlobalMetadata<C> metadata = MetadataLoader.<C> loadGlobal(name, description, defaultCommandMetadata,
-                ListUtils.unmodifiableList(defaultCommandGroup), ListUtils.unmodifiableList(commandGroups),
-                ListUtils.unmodifiableList(restrictions), Collections.unmodifiableCollection(baseHelpSections.values()),
-                this.parserBuilder.build());
+                                                                   ListUtils.unmodifiableList(defaultCommandGroup), ListUtils.unmodifiableList(commandGroups),
+                                                                   ListUtils.unmodifiableList(restrictions), Collections.unmodifiableCollection(baseHelpSections.values()),
+                                                                   parserConfig);
 
         return new Cli<C>(metadata);
     }

--- a/airline-core/src/main/java/com/github/rvesse/airline/builder/ParserBuilder.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/builder/ParserBuilder.java
@@ -16,13 +16,12 @@
 package com.github.rvesse.airline.builder;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import com.github.rvesse.airline.CommandFactory;
 import com.github.rvesse.airline.DefaultCommandFactory;
 import com.github.rvesse.airline.model.AliasMetadata;
+import com.github.rvesse.airline.model.MetadataLoader;
 import com.github.rvesse.airline.model.ParserMetadata;
 import com.github.rvesse.airline.parser.aliases.UserAliasesSource;
 import com.github.rvesse.airline.parser.errors.handlers.ParserErrorHandler;
@@ -39,8 +38,7 @@ import com.github.rvesse.airline.types.numerics.NumericTypeConverter;
 /**
  * Builder for parser configurations
  *
- * @param <C>
- *            Command type
+ * @param <C> Command type
  */
 public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
@@ -54,12 +52,12 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
     protected String argsSeparator, flagNegationPrefix;
     protected UserAliasSourceBuilder<C> userAliasesBuilder = new UserAliasSourceBuilder<>(this);
     protected ParserErrorHandler errorHandler;
+    protected Set<String> injectionAnnotationClasses = new LinkedHashSet<>();
 
     /**
      * Gets the default configuration
-     * 
-     * @param <T>
-     *            Command type to parse
+     *
+     * @param <T> Command type to parse
      * @return Default configuration
      */
     public static <T> ParserMetadata<T> defaultConfiguration() {
@@ -68,9 +66,8 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Specifies the command factory to use
-     * 
-     * @param commandFactory
-     *            Command Factory
+     *
+     * @param commandFactory Command Factory
      * @return Builder
      */
     public ParserBuilder<C> withCommandFactory(CommandFactory<C> commandFactory) {
@@ -80,7 +77,7 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Specifies that the default command factory should be used
-     * 
+     *
      * @return Builder
      */
     public ParserBuilder<C> withDefaultCommandFactory() {
@@ -88,11 +85,26 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
         return this;
     }
 
+    public ParserBuilder<C> withInjectionAnnotations(Collection<String> annotationClassNames) {
+        if (annotationClassNames != null) {
+            this.injectionAnnotationClasses.addAll(annotationClassNames);
+        }
+        return this;
+    }
+
+    public ParserBuilder<C> withInjectionAnnotations(String... annotationClassNames) {
+        return withInjectionAnnotations(Arrays.asList(annotationClassNames));
+    }
+
+    public ParserBuilder<C> withDefaultInjectionAnnotations() {
+        return withInjectionAnnotations(MetadataLoader.JAVAX_INJECT_INJECT, MetadataLoader.JAKARTA_INJECT_INJECT,
+                                        MetadataLoader.COM_GOOGLE_INJECT_INJECT);
+    }
+
     /**
      * Adds an alias
-     * 
-     * @param name
-     *            Alias name
+     *
+     * @param name Alias name
      * @return Alias Builder
      */
     public AliasBuilder<C> withAlias(final String name) {
@@ -109,25 +121,23 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Retrieves an alias builder for the given alias
-     * 
-     * @param name
-     *            Alias name
+     *
+     * @param name Alias name
      * @return Alias Builder
      */
     public AliasBuilder<C> getAlias(final String name) {
         checkNotBlank(name, "Alias name");
-        if (!aliases.containsKey(name))
+        if (!aliases.containsKey(name)) {
             throw new IllegalArgumentException(String.format("Alias %s has not been declared", name));
+        }
 
         return aliases.get(name);
     }
 
     /**
-     * Sets a prefix character used in alias definitions to force use of a
-     * built-in as opposed to a chained alias
-     * 
-     * @param prefix
-     *            Prefic character
+     * Sets a prefix character used in alias definitions to force use of a built-in as opposed to a chained alias
+     *
+     * @param prefix Prefic character
      * @return Parser build
      */
     public ParserBuilder<C> withAliasForceBuiltInPrefix(char prefix) {
@@ -137,7 +147,7 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Gets a builder that provides detailed control over building user aliases
-     * 
+     *
      * @return User aliases builder
      */
     public UserAliasSourceBuilder<C> withUserAliases() {
@@ -145,27 +155,23 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
     }
 
     /**
-     * Reads in user aliases from the default configuration file in the default
-     * location.
+     * Reads in user aliases from the default configuration file in the default location.
      * <p>
-     * The default configuration file name is constructed by appending the
-     * {@code .config} extension to the defined program name
+     * The default configuration file name is constructed by appending the {@code .config} extension to the defined
+     * program name
      * </p>
      * <p>
-     * The default search location is a {@code .program} directory under the
-     * users home directory where {@code program} is the defined program name.
+     * The default search location is a {@code .program} directory under the users home directory where {@code program}
+     * is the defined program name.
      * </p>
      * <p>
-     * If you prefer to control these values explicitly and for more detail on
-     * the configuration format please see the
+     * If you prefer to control these values explicitly and for more detail on the configuration format please see the
      * {@link #withUserAliases(String, String, String...)} method
      * </p>
-     * 
-     * @param programName
-     *            Program Name
+     *
+     * @param programName Program Name
      * @return Builder
-     * @deprecated Use {@link #withUserAliases()} to access the user alias
-     *             builder directly instead
+     * @deprecated Use {@link #withUserAliases()} to access the user alias builder directly instead
      */
     @Deprecated
     public ParserBuilder<C> withUserAliases(String programName) {
@@ -176,26 +182,20 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
     }
 
     /**
-     * Reads in user aliases from the default configuration file in the default
-     * location
+     * Reads in user aliases from the default configuration file in the default location
      * <p>
-     * The default configuration file name is constructed by appending the
-     * {@code .config} extension to the defined program name
+     * The default configuration file name is constructed by appending the {@code .config} extension to the defined
+     * program name
      * </p>
      * <p>
-     * If you prefer to control this value explicitly and for more detail on the
-     * configuration format please see the
+     * If you prefer to control this value explicitly and for more detail on the configuration format please see the
      * {@link #withUserAliases(String, String, String...)} method
      * </p>
-     * 
-     * @param programName
-     *            Program name
-     * @param searchLocation
-     *            Location to search
-     * 
+     *
+     * @param programName    Program name
+     * @param searchLocation Location to search
      * @return Builder
-     * @deprecated Use {@link #withUserAliases()} to access the user alias
-     *             builder directly instead
+     * @deprecated Use {@link #withUserAliases()} to access the user alias builder directly instead
      */
     @Deprecated
     public ParserBuilder<C> withUserAliases(String programName, String searchLocation) {
@@ -206,40 +206,32 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
     }
 
     /**
-     * Reads in user aliases from the defined configuration file in the provided
-     * search locations
+     * Reads in user aliases from the defined configuration file in the provided search locations
      * <p>
-     * This file is in standard Java properties format with the key being the
-     * alias and the value being the arguments for this alias. Arguments are
-     * whitespace separated though quotes ({@code "}) may be used to wrap
-     * arguments that need to contain whitespace. Quotes may be escaped within
-     * quoted arguments and whitespace may be escaped within unquoted arguments.
-     * Note that since Java property values are interpreted as Java strings it
-     * is necessary to double escape the backslash i.e. {@code \\"} for this to
-     * work properly.
+     * This file is in standard Java properties format with the key being the alias and the value being the arguments
+     * for this alias. Arguments are whitespace separated though quotes ({@code "}) may be used to wrap arguments that
+     * need to contain whitespace. Quotes may be escaped within quoted arguments and whitespace may be escaped within
+     * unquoted arguments. Note that since Java property values are interpreted as Java strings it is necessary to
+     * double escape the backslash i.e. {@code \\"} for this to work properly.
      * </p>
-     * 
+     *
      * <pre>
      * example=command --option value
      * quoted=command "long argument"
      * escaped=command whitespace\\ escape "quote\\"escape"
      * </pre>
      * <p>
-     * The search locations should be given in order of preference, the file
-     * will be loaded from all search locations in which it exists such that
-     * values from the locations occurring first in the search locations list
-     * take precedence. This allows for having multiple locations for your
-     * configuration file and layering different sets of aliases over each other
-     * e.g. system, user and local aliases.
+     * The search locations should be given in order of preference, the file will be loaded from all search locations in
+     * which it exists such that values from the locations occurring first in the search locations list take precedence.
+     * This allows for having multiple locations for your configuration file and layering different sets of aliases over
+     * each other e.g. system, user and local aliases.
      * </p>
      * <p>
-     * The {@code prefix} is used to filter properties from the properties file
-     * such that you can include aliases with other configuration settings in
-     * your configuration files. When a prefix is used only properties that
-     * start with the prefix are interpreted as alias definitions and the actual
-     * alias is the property name with the prefix removed. For example if your
-     * prefix was {@code alias.} and you had a property {@code alias.foo} the
-     * resulting alias would be {@code foo}.
+     * The {@code prefix} is used to filter properties from the properties file such that you can include aliases with
+     * other configuration settings in your configuration files. When a prefix is used only properties that start with
+     * the prefix are interpreted as alias definitions and the actual alias is the property name with the prefix
+     * removed. For example if your prefix was {@code alias.} and you had a property {@code alias.foo} the resulting
+     * alias would be {@code foo}.
      * </p>
      * <h3>Notes</h3>
      * <ul>
@@ -250,22 +242,16 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
      * <li>Aliases cannot override built-ins unless you have called
      * {@link #withAliasesOverridingBuiltIns()} on your builder</li>
      * </ul>
-     * 
-     * @param filename
-     *            Filename to look for
-     * @param prefix
-     *            Prefix used to distinguish alias related properties from other
-     *            properties
-     * @param searchLocations
-     *            Search locations in order of preference
-     * 
+     *
+     * @param filename        Filename to look for
+     * @param prefix          Prefix used to distinguish alias related properties from other properties
+     * @param searchLocations Search locations in order of preference
      * @return Builder
-     * @deprecated Use {@link #withUserAliases()} to access the user alias
-     *             builder directly instead
+     * @deprecated Use {@link #withUserAliases()} to access the user alias builder directly instead
      */
     @Deprecated
     public ParserBuilder<C> withUserAliases(final String filename, final String prefix,
-            final String... searchLocations) {
+                                            final String... searchLocations) {
         this.userAliasesBuilder.withFilename(filename);
         this.userAliasesBuilder.withPrefix(prefix);
         this.userAliasesBuilder.withSearchLocations(searchLocations);
@@ -273,40 +259,32 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
     }
 
     /**
-     * Reads in user aliases from the defined configuration file in the provided
-     * search location
+     * Reads in user aliases from the defined configuration file in the provided search location
      * <p>
-     * This file is in standard Java properties format with the key being the
-     * alias and the value being the arguments for this alias. Arguments are
-     * whitespace separated though quotes ({@code "}) may be used to wrap
-     * arguments that need to contain whitespace. Quotes may be escaped within
-     * quoted arguments and whitespace may be escaped within unquoted arguments.
-     * Note that since Java property values are interpreted as Java strings it
-     * is necessary to double escape the backslash i.e. {@code \\"} for this to
-     * work properly.
+     * This file is in standard Java properties format with the key being the alias and the value being the arguments
+     * for this alias. Arguments are whitespace separated though quotes ({@code "}) may be used to wrap arguments that
+     * need to contain whitespace. Quotes may be escaped within quoted arguments and whitespace may be escaped within
+     * unquoted arguments. Note that since Java property values are interpreted as Java strings it is necessary to
+     * double escape the backslash i.e. {@code \\"} for this to work properly.
      * </p>
-     * 
+     *
      * <pre>
      * example=command --option value
      * quoted=command "long argument"
      * escaped=command whitespace\\ escape "quote\\"escape"
      * </pre>
      * <p>
-     * The search locations should be given in order of preference, the file
-     * will be loaded from all search locations in which it exists such that
-     * values from the locations occurring first in the search locations list
-     * take precedence. This allows for having multiple locations for your
-     * configuration file and layering different sets of aliases over each other
-     * e.g. system, user and local aliases.
+     * The search locations should be given in order of preference, the file will be loaded from all search locations in
+     * which it exists such that values from the locations occurring first in the search locations list take precedence.
+     * This allows for having multiple locations for your configuration file and layering different sets of aliases over
+     * each other e.g. system, user and local aliases.
      * </p>
      * <p>
-     * The {@code prefix} is used to filter properties from the properties file
-     * such that you can include aliases with other configuration settings in
-     * your configuration files. When a prefix is used only properties that
-     * start with the prefix are interpreted as alias definitions and the actual
-     * alias is the property name with the prefix removed. For example if your
-     * prefix was {@code alias.} and you had a property {@code alias.foo} the
-     * resulting alias would be {@code foo}.
+     * The {@code prefix} is used to filter properties from the properties file such that you can include aliases with
+     * other configuration settings in your configuration files. When a prefix is used only properties that start with
+     * the prefix are interpreted as alias definitions and the actual alias is the property name with the prefix
+     * removed. For example if your prefix was {@code alias.} and you had a property {@code alias.foo} the resulting
+     * alias would be {@code foo}.
      * </p>
      * <h3>Notes</h3>
      * <ul>
@@ -317,27 +295,19 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
      * <li>Aliases cannot override built-ins unless you have called
      * {@link #withAliasesOverridingBuiltIns()} on your builder</li>
      * </ul>
-     * 
-     * @param filename
-     *            Filename to look for
-     * @param prefix
-     *            Prefix used to distinguish alias related properties from other
-     *            properties
-     * @param locators
-     *            Locators used to resolve search locations to actual locations,
-     *            this is what enables things like {@code ~/} to be used to
-     *            refer to the users home directory. If {@code null} then a
-     *            default set are used.
-     * @param searchLocations
-     *            Search locations in order of preference
-     * 
+     *
+     * @param filename        Filename to look for
+     * @param prefix          Prefix used to distinguish alias related properties from other properties
+     * @param locators        Locators used to resolve search locations to actual locations, this is what enables things
+     *                        like {@code ~/} to be used to refer to the users home directory. If {@code null} then a
+     *                        default set are used.
+     * @param searchLocations Search locations in order of preference
      * @return Builder
-     * @deprecated Use {@link #withUserAliases()} to access the user alias
-     *             builder directly instead
+     * @deprecated Use {@link #withUserAliases()} to access the user alias builder directly instead
      */
     @Deprecated
     public ParserBuilder<C> withUserAliases(final String filename, final String prefix,
-            final List<ResourceLocator> locators, final String... searchLocations) {
+                                            final List<ResourceLocator> locators, final String... searchLocations) {
         this.userAliasesBuilder.withFilename(filename);
         this.userAliasesBuilder.withPrefix(prefix);
         this.userAliasesBuilder.withSearchLocations(searchLocations);
@@ -347,7 +317,7 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Sets that aliases should override built-in commands
-     * 
+     *
      * @return Builder
      */
     public ParserBuilder<C> withAliasesOverridingBuiltIns() {
@@ -357,7 +327,7 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Sets that aliases may be defined in terms of other aliases
-     * 
+     *
      * @return Builder
      */
     public ParserBuilder<C> withAliasesChaining() {
@@ -367,7 +337,7 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Sets that command abbreviation is enabled
-     * 
+     *
      * @return Builder
      */
     public ParserBuilder<C> withCommandAbbreviation() {
@@ -377,7 +347,7 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Sets that option abbreviation is enabled
-     * 
+     *
      * @return Builder
      */
     public ParserBuilder<C> withOptionAbbreviation() {
@@ -387,9 +357,8 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Sets the type converter for the parser
-     * 
-     * @param converter
-     *            Type converter
+     *
+     * @param converter Type converter
      * @return Builder
      */
     public ParserBuilder<C> withTypeConverter(TypeConverter converter) {
@@ -399,7 +368,7 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Sets that the default type converter should be used
-     * 
+     *
      * @return Builder
      */
     public ParserBuilder<C> withDefaultTypeConverter() {
@@ -408,11 +377,9 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
     }
 
     /**
-     * Indicates the desired numeric type converter to use, this is passed as an
-     * argument to the given type converter
-     * 
-     * @param converter
-     *            Numeric type converter
+     * Indicates the desired numeric type converter to use, this is passed as an argument to the given type converter
+     *
+     * @param converter Numeric type converter
      * @return Builder
      */
     public ParserBuilder<C> withNumericTypeConverter(NumericTypeConverter converter) {
@@ -422,7 +389,7 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Indicates that default numeric type conversion should be used
-     * 
+     *
      * @return Builder
      */
     public ParserBuilder<C> withDefaultNumericTypeConverter() {
@@ -432,9 +399,8 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Sets the error handler to use
-     * 
-     * @param errorHandler
-     *            Error handler
+     *
+     * @param errorHandler Error handler
      * @return Builder
      */
     public ParserBuilder<C> withErrorHandler(ParserErrorHandler errorHandler) {
@@ -444,7 +410,7 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     /**
      * Sets that the default error handler should be used
-     * 
+     *
      * @return Builder
      */
     public ParserBuilder<C> withDefaultErrorHandler() {
@@ -455,12 +421,11 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
     /**
      * Configures the CLI to use the given option parser
      * <p>
-     * Order of registration is important, if you have previously registered any
-     * parsers then those will be used prior to the one given here
+     * Order of registration is important, if you have previously registered any parsers then those will be used prior
+     * to the one given here
      * </p>
-     * 
-     * @param optionParser
-     *            Option parser
+     *
+     * @param optionParser Option parser
      * @return Builder
      */
     public ParserBuilder<C> withOptionParser(OptionParser<C> optionParser) {
@@ -473,12 +438,11 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
     /**
      * Configures the CLI to use the given option parsers
      * <p>
-     * Order of registration is important, if you have previously registered any
-     * parsers then those will be used prior to those given here
+     * Order of registration is important, if you have previously registered any parsers then those will be used prior
+     * to those given here
      * </p>
-     * 
-     * @param optionParsers
-     *            Option parsers
+     *
+     * @param optionParsers Option parsers
      * @return Builder
      */
     @SuppressWarnings("unchecked")
@@ -496,17 +460,15 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
     /**
      * Configures the CLI to use only the default set of option parsers
      * <p>
-     * This is the default behaviour so this need only be called if you have
-     * previously configured some option parsers using the
-     * {@link #withOptionParser(OptionParser)} or
-     * {@link #withOptionParsers(OptionParser...)} methods and wish to reset the
-     * configuration to the default.
+     * This is the default behaviour so this need only be called if you have previously configured some option parsers
+     * using the {@link #withOptionParser(OptionParser)} or {@link #withOptionParsers(OptionParser...)} methods and wish
+     * to reset the configuration to the default.
      * </p>
      * <p>
-     * If you wish to instead add the default parsers in addition to your custom
-     * parsers you should instead call {@link #withDefaultOptionParsers()}
+     * If you wish to instead add the default parsers in addition to your custom parsers you should instead call
+     * {@link #withDefaultOptionParsers()}
      * </p>
-     * 
+     *
      * @return Builder
      */
     public ParserBuilder<C> withOnlyDefaultOptionParsers() {
@@ -515,33 +477,29 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
     }
 
     /**
-     * Configures the CLI to use the default set of option parsers in addition
-     * to any previously registered
+     * Configures the CLI to use the default set of option parsers in addition to any previously registered
      * <p>
-     * Order of registration is important, if you have previously registered any
-     * parsers then those will be used prior to those in the default set.
+     * Order of registration is important, if you have previously registered any parsers then those will be used prior
+     * to those in the default set.
      * </p>
-     * 
+     *
      * @return Builder
      */
     @SuppressWarnings("unchecked")
     public ParserBuilder<C> withDefaultOptionParsers() {
         return this.withOptionParsers(new StandardOptionParser<C>(), new LongGetOptParser<C>(),
-                new ClassicGetOptParser<C>());
+                                      new ClassicGetOptParser<C>());
     }
 
     /**
-     * Sets the arguments separator, this is a token used to indicate the point
-     * at which no further options will be seen and all further tokens should be
-     * treated as arguments.
+     * Sets the arguments separator, this is a token used to indicate the point at which no further options will be seen
+     * and all further tokens should be treated as arguments.
      * <p>
-     * This is useful for disambiguating where arguments may be misinterpreted
-     * as options. The default value of this is the standard {@code --} used by
-     * many command line tools.
+     * This is useful for disambiguating where arguments may be misinterpreted as options. The default value of this is
+     * the standard {@code --} used by many command line tools.
      * </p>
-     * 
-     * @param separator
-     *            Arguments separator
+     *
+     * @param separator Arguments separator
      * @return Builder
      */
     public ParserBuilder<C> withArgumentsSeparator(String separator) {
@@ -550,14 +508,12 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
     }
 
     /**
-     * Sets the flag negation prefix, this is used to determine whether to set a
-     * flag option (a zero arity option) to {@code false} rather than the usual
-     * behaviour of setting it to {@code true}. Options must have appropriately
-     * prefixed names defined for this prefix to have any effect i.e. setting it
-     * does not automatically enable negation for flag options.
-     * 
-     * @param prefix
-     *            Flag negation prefix
+     * Sets the flag negation prefix, this is used to determine whether to set a flag option (a zero arity option) to
+     * {@code false} rather than the usual behaviour of setting it to {@code true}. Options must have appropriately
+     * prefixed names defined for this prefix to have any effect i.e. setting it does not automatically enable negation
+     * for flag options.
+     *
+     * @param prefix Flag negation prefix
      * @return Builder
      */
     public ParserBuilder<C> withFlagNegationPrefix(String prefix) {
@@ -567,6 +523,10 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
 
     @Override
     public ParserMetadata<C> build() {
+        // Ensure we have some injection annotations if none configured
+        if (this.injectionAnnotationClasses.size() == 0) {
+            this.withDefaultInjectionAnnotations();
+        }
         // Ensure we have some option parsers if none configured
         if (this.optionParsers.size() == 0) {
             this.withDefaultOptionParsers();
@@ -579,8 +539,8 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
             try {
                 userAliases = this.userAliasesBuilder.build();
                 for (AliasMetadata alias : userAliases.load()) {
-                    aliases.put(alias.getName(), new AliasBuilder<C>(this, alias.getName())
-                            .withArguments(alias.getArguments().toArray(new String[alias.getArguments().size()])));
+                    aliases.put(alias.getName(), new AliasBuilder<C>(this, alias.getName()).withArguments(
+                            alias.getArguments().toArray(new String[alias.getArguments().size()])));
                 }
             } catch (IOException e) {
                 throw new IllegalStateException("Failed to load user aliases", e);
@@ -603,8 +563,9 @@ public class ParserBuilder<C> extends AbstractBuilder<ParserMetadata<C>> {
         }
         typeConverter.setNumericConverter(this.numericTypeConverter);
 
-        return new ParserMetadata<C>(commandFactory, optionParsers, typeConverter, errorHandler,
-                allowAbbreviatedCommands, allowAbbreviatedOptions, aliasData, userAliases, aliasesOverrideBuiltIns,
-                aliasesMayChain, forceBuiltInPrefix, argsSeparator, flagNegationPrefix);
+        return new ParserMetadata<C>(commandFactory, injectionAnnotationClasses, optionParsers, typeConverter,
+                                     errorHandler, allowAbbreviatedCommands, allowAbbreviatedOptions, aliasData,
+                                     userAliases, aliasesOverrideBuiltIns, aliasesMayChain, forceBuiltInPrefix,
+                                     argsSeparator, flagNegationPrefix);
     }
 }

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/Help.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/Help.java
@@ -15,12 +15,8 @@
  */
 package com.github.rvesse.airline.help;
 
-import jakarta.inject.Inject;
-
 import com.github.rvesse.airline.Channels;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
@@ -35,6 +31,8 @@ import com.github.rvesse.airline.utils.predicates.parser.AbbreviatedCommandFinde
 import com.github.rvesse.airline.utils.predicates.parser.AbbreviatedGroupFinder;
 import com.github.rvesse.airline.utils.predicates.parser.CommandFinder;
 import com.github.rvesse.airline.utils.predicates.parser.GroupFinder;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -44,7 +42,7 @@ import java.util.concurrent.Callable;
 
 @Command(name = "help", description = "Display help information")
 public class Help<T> implements Runnable, Callable<Void> {
-    @Inject
+    @AirlineModule
     public GlobalMetadata<T> global;
 
     @Arguments

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/Help.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/Help.java
@@ -15,7 +15,7 @@
  */
 package com.github.rvesse.airline.help;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.Channels;
 import org.apache.commons.collections4.CollectionUtils;

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/CommandSuggester.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/CommandSuggester.java
@@ -15,22 +15,20 @@
  */
 package com.github.rvesse.airline.help.suggester;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.model.CommandMetadata;
 import com.github.rvesse.airline.model.MetadataLoader;
 import com.github.rvesse.airline.model.OptionMetadata;
 import com.github.rvesse.airline.model.ParserMetadata;
-
-import jakarta.inject.Inject;
-
 import org.apache.commons.collections4.ListUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class CommandSuggester
         implements Suggester
 {
-    @Inject
+    @AirlineModule
     public CommandMetadata command;
 
     @Override

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/CommandSuggester.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/CommandSuggester.java
@@ -23,7 +23,7 @@ import com.github.rvesse.airline.model.MetadataLoader;
 import com.github.rvesse.airline.model.OptionMetadata;
 import com.github.rvesse.airline.model.ParserMetadata;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.apache.commons.collections4.ListUtils;
 

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/GlobalSuggester.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/GlobalSuggester.java
@@ -18,7 +18,7 @@ package com.github.rvesse.airline.help.suggester;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.apache.commons.collections4.ListUtils;
 

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/GlobalSuggester.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/GlobalSuggester.java
@@ -15,22 +15,20 @@
  */
 package com.github.rvesse.airline.help.suggester;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import jakarta.inject.Inject;
-
-import org.apache.commons.collections4.ListUtils;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.model.CommandGroupMetadata;
 import com.github.rvesse.airline.model.CommandMetadata;
 import com.github.rvesse.airline.model.GlobalMetadata;
 import com.github.rvesse.airline.model.OptionMetadata;
+import org.apache.commons.collections4.ListUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class GlobalSuggester<T>
     implements Suggester
 {
-    @Inject
+    @AirlineModule
     public GlobalMetadata<T> metadata;
 
     @Override

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/GroupSuggester.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/GroupSuggester.java
@@ -15,19 +15,17 @@
  */
 package com.github.rvesse.airline.help.suggester;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import jakarta.inject.Inject;
-
-import org.apache.commons.collections4.ListUtils;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.model.CommandGroupMetadata;
 import com.github.rvesse.airline.model.CommandMetadata;
 import com.github.rvesse.airline.model.OptionMetadata;
+import org.apache.commons.collections4.ListUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class GroupSuggester implements Suggester {
-    @Inject
+    @AirlineModule
     public CommandGroupMetadata group;
 
     @Override

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/GroupSuggester.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/GroupSuggester.java
@@ -18,7 +18,7 @@ package com.github.rvesse.airline.help.suggester;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.apache.commons.collections4.ListUtils;
 

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/SuggestCommand.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/SuggestCommand.java
@@ -17,27 +17,16 @@ package com.github.rvesse.airline.help.suggester;
 
 import com.github.rvesse.airline.Channels;
 import com.github.rvesse.airline.Context;
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
-import com.github.rvesse.airline.model.CommandGroupMetadata;
-import com.github.rvesse.airline.model.CommandMetadata;
-import com.github.rvesse.airline.model.GlobalMetadata;
-import com.github.rvesse.airline.model.MetadataLoader;
-import com.github.rvesse.airline.model.OptionMetadata;
-import com.github.rvesse.airline.model.SuggesterMetadata;
+import com.github.rvesse.airline.model.*;
 import com.github.rvesse.airline.parser.ParseState;
 import com.github.rvesse.airline.parser.suggester.SuggestionParser;
 import com.github.rvesse.airline.utils.AirlineUtils;
-
-import jakarta.inject.Inject;
-
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.Callable;
 
 import static com.github.rvesse.airline.parser.ParserUtil.createInstance;
@@ -52,7 +41,7 @@ public class SuggestCommand<T> implements Runnable, Callable<Void> {
         BUILTIN_SUGGESTERS.put(Context.COMMAND, CommandSuggester.class);
     }
 
-    @Inject
+    @AirlineModule
     public GlobalMetadata<T> metadata;
 
     @Arguments

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/SuggestCommand.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/SuggestCommand.java
@@ -29,7 +29,7 @@ import com.github.rvesse.airline.parser.ParseState;
 import com.github.rvesse.airline.parser.suggester.SuggestionParser;
 import com.github.rvesse.airline.utils.AirlineUtils;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/SuggestCommand.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/help/suggester/SuggestCommand.java
@@ -64,7 +64,9 @@ public class SuggestCommand<T> implements Runnable, Callable<Void> {
 
         Class<? extends Suggester> suggesterClass = BUILTIN_SUGGESTERS.get(state.getLocation());
         if (suggesterClass != null) {
-            SuggesterMetadata suggesterMetadata = MetadataLoader.loadSuggester(suggesterClass);
+            SuggesterMetadata suggesterMetadata =
+                    MetadataLoader.loadSuggester(suggesterClass, MetadataLoader.loadParser(
+                            this.getClass()));
 
             if (suggesterMetadata != null) {
                 Map<Class<?>, Object> bindings = new HashMap<Class<?>, Object>();
@@ -79,8 +81,9 @@ public class SuggestCommand<T> implements Runnable, Callable<Void> {
                 }
 
                 Suggester suggester = createInstance(suggesterMetadata.getSuggesterClass(),
-                        Collections.<OptionMetadata> emptyList(), null, null, null,
-                        suggesterMetadata.getMetadataInjections(), AirlineUtils.unmodifiableMapCopy(bindings));
+                                                     Collections.<OptionMetadata>emptyList(), null, null, null,
+                                                     suggesterMetadata.getMetadataInjections(),
+                                                     AirlineUtils.unmodifiableMapCopy(bindings));
 
                 return suggester.suggest();
             }

--- a/airline-core/src/main/java/com/github/rvesse/airline/model/MetadataLoader.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/model/MetadataLoader.java
@@ -104,10 +104,10 @@ public class MetadataLoader {
         } else {
             builder = builder.withDefaultCommandFactory();
         }
-        if (parserConfig.injectionAnnotationClasses().length > 0) {
-            builder = builder.withInjectionAnnotations(parserConfig.injectionAnnotationClasses());
+        if (parserConfig.compositionAnnotationClasses().length > 0) {
+            builder = builder.withCompositionAnnotations(parserConfig.compositionAnnotationClasses());
         } else {
-            builder = builder.withDefaultInjectionAnnotations();
+            builder = builder.withDefaultCompositionAnnotations();
         }
         if (!parserConfig.errorHandler().equals(FailFast.class)) {
             builder = builder.withErrorHandler(ParserUtil.createInstance(parserConfig.errorHandler()));
@@ -620,7 +620,7 @@ public class MetadataLoader {
                 // because it was in the codebase historically and people may still be using it.
                 // See #81 for discussion of planned future changes around introducing our own annotation instead of
                 // reusing the existing ones
-                for (String injectionAnnotation : parserConfig.getInjectionAnnotations()) {
+                for (String injectionAnnotation : parserConfig.getCompositionAnnotations()) {
                     checkForInjectionAnnotation(injectionMetadata, field, path, injectionAnnotation, parserConfig);
                 }
 

--- a/airline-core/src/main/java/com/github/rvesse/airline/model/ParserMetadata.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/model/ParserMetadata.java
@@ -16,10 +16,10 @@
 package com.github.rvesse.airline.model;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import com.github.rvesse.airline.annotations.AirlineModule;
 import org.apache.commons.lang3.StringUtils;
 
 import com.github.rvesse.airline.CommandFactory;
@@ -51,9 +51,9 @@ public class ParserMetadata<T> {
     private final String argsSeparator, flagNegationPrefix;
     private final ParserErrorHandler errorHandler;
     private final char forceBuiltInPrefix;
-    private final Set<String> injectAnnotationClasses;
+    private final Set<String> compositionAnnotationClasses;
 
-    public ParserMetadata(CommandFactory<T> commandFactory, Collection<String> injectAnnotationClasses,
+    public ParserMetadata(CommandFactory<T> commandFactory, Collection<String> compositionAnnotationClasses,
                           Collection<OptionParser<T>> optionParsers,
                           TypeConverter typeConverter, ParserErrorHandler errorHandler, boolean allowAbbreviateCommands,
                           boolean allowAbbreviatedOptions, Collection<AliasMetadata> aliases,
@@ -73,7 +73,7 @@ public class ParserMetadata<T> {
         // Command parsing
         this.commandFactory = commandFactory != null ? commandFactory : new DefaultCommandFactory<T>();
         this.allowAbbreviatedCommands = allowAbbreviateCommands;
-        this.injectAnnotationClasses = AirlineUtils.unmodifiableSetCopy(injectAnnotationClasses);
+        this.compositionAnnotationClasses = AirlineUtils.unmodifiableSetCopy(compositionAnnotationClasses);
 
         // Option Parsing
         this.typeConverter = typeConverter != null ? typeConverter : new DefaultTypeConverter();
@@ -112,11 +112,19 @@ public class ParserMetadata<T> {
 
     /**
      * Gets the set of annotation class names to follow when building the metadata for commands i.e. these are the
-     * annotations like {@code javax.inject.Inject} that indicate that a field has a type that should be inspected for
+     * annotations like {@link AirlineModule} that indicate that a field has a type that should be inspected for
      * further metadata used to build up a commands options and arguments.
+     * <p>
+     * This configuration point was introduced in <strong>2.9.0</strong> along with the {@link AirlineModule} annotation
+     * to allow better integrating Airline with a dependency injection framework, and to ultimately enable removing its
+     * current dependency on the {@code jakarta-inject} library.
+     * </p>
+     *
+     * @return Collection of injection annotation class names
+     * @since 2.9.0
      */
-    public Collection<String> getInjectionAnnotations() {
-        return this.injectAnnotationClasses;
+    public Collection<String> getCompositionAnnotations() {
+        return this.compositionAnnotationClasses;
     }
 
     /**

--- a/airline-core/src/main/java/com/github/rvesse/airline/model/ParserMetadata.java
+++ b/airline-core/src/main/java/com/github/rvesse/airline/model/ParserMetadata.java
@@ -15,7 +15,10 @@
  */
 package com.github.rvesse.airline.model;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -48,16 +51,21 @@ public class ParserMetadata<T> {
     private final String argsSeparator, flagNegationPrefix;
     private final ParserErrorHandler errorHandler;
     private final char forceBuiltInPrefix;
+    private final Set<String> injectAnnotationClasses;
 
-    public ParserMetadata(CommandFactory<T> commandFactory, List<OptionParser<T>> optionParsers,
-            TypeConverter typeConverter, ParserErrorHandler errorHandler, boolean allowAbbreviateCommands,
-            boolean allowAbbreviatedOptions, List<AliasMetadata> aliases, UserAliasesSource<T> userAliases,
-            boolean aliasesOverrideBuiltIns, boolean aliasesMayChain, char forceBuiltInPrefix,
-            String argumentsSeparator, String flagNegationPrefix) {
-        if (optionParsers == null)
+    public ParserMetadata(CommandFactory<T> commandFactory, Collection<String> injectAnnotationClasses,
+                          Collection<OptionParser<T>> optionParsers,
+                          TypeConverter typeConverter, ParserErrorHandler errorHandler, boolean allowAbbreviateCommands,
+                          boolean allowAbbreviatedOptions, Collection<AliasMetadata> aliases,
+                          UserAliasesSource<T> userAliases,
+                          boolean aliasesOverrideBuiltIns, boolean aliasesMayChain, char forceBuiltInPrefix,
+                          String argumentsSeparator, String flagNegationPrefix) {
+        if (optionParsers == null) {
             throw new NullPointerException("optionParsers cannot be null");
-        if (aliases == null)
+        }
+        if (aliases == null) {
             throw new NullPointerException("aliases cannot be null");
+        }
 
         // Error handling
         this.errorHandler = errorHandler != null ? errorHandler : new FailFast();
@@ -65,6 +73,7 @@ public class ParserMetadata<T> {
         // Command parsing
         this.commandFactory = commandFactory != null ? commandFactory : new DefaultCommandFactory<T>();
         this.allowAbbreviatedCommands = allowAbbreviateCommands;
+        this.injectAnnotationClasses = AirlineUtils.unmodifiableSetCopy(injectAnnotationClasses);
 
         // Option Parsing
         this.typeConverter = typeConverter != null ? typeConverter : new DefaultTypeConverter();
@@ -80,11 +89,12 @@ public class ParserMetadata<T> {
 
         // Arguments Separator
         if (StringUtils.isNotEmpty(argumentsSeparator)) {
-            if (StringUtils.containsWhitespace(argumentsSeparator))
+            if (StringUtils.containsWhitespace(argumentsSeparator)) {
                 throw new IllegalArgumentException("argumentsSeparator cannot contain any whitespace");
+            }
         }
         this.argsSeparator = StringUtils.isNotEmpty(argumentsSeparator) ? argumentsSeparator
-                : DEFAULT_ARGUMENTS_SEPARATOR;
+                                                                        : DEFAULT_ARGUMENTS_SEPARATOR;
 
         // Flag negation
         this.flagNegationPrefix = StringUtils.isNotEmpty(flagNegationPrefix) ? flagNegationPrefix : null;
@@ -93,7 +103,7 @@ public class ParserMetadata<T> {
 
     /**
      * Gets the command factory to use
-     * 
+     *
      * @return Command factory
      */
     public CommandFactory<T> getCommandFactory() {
@@ -101,8 +111,17 @@ public class ParserMetadata<T> {
     }
 
     /**
+     * Gets the set of annotation class names to follow when building the metadata for commands i.e. these are the
+     * annotations like {@code javax.inject.Inject} that indicate that a field has a type that should be inspected for
+     * further metadata used to build up a commands options and arguments.
+     */
+    public Collection<String> getInjectionAnnotations() {
+        return this.injectAnnotationClasses;
+    }
+
+    /**
      * Gets the type converter to use
-     * 
+     *
      * @return Type converter
      */
     public TypeConverter getTypeConverter() {
@@ -111,7 +130,7 @@ public class ParserMetadata<T> {
 
     /**
      * Gets the error handler to use
-     * 
+     *
      * @return Error handler
      */
     public ParserErrorHandler getErrorHandler() {
@@ -120,7 +139,7 @@ public class ParserMetadata<T> {
 
     /**
      * Gets the defined command aliases
-     * 
+     *
      * @return Aliases
      */
     public List<AliasMetadata> getAliases() {
@@ -129,7 +148,7 @@ public class ParserMetadata<T> {
 
     /**
      * Gets the user aliases source (if any)
-     * 
+     *
      * @return User aliases source
      */
     public UserAliasesSource<T> getUserAliasesSource() {
@@ -138,7 +157,7 @@ public class ParserMetadata<T> {
 
     /**
      * Gets whether aliases can override built-in commands
-     * 
+     *
      * @return True if they can override, false otherwise
      */
     public boolean aliasesOverrideBuiltIns() {
@@ -146,9 +165,8 @@ public class ParserMetadata<T> {
     }
 
     /**
-     * Gets whether aliases may chain i.e. whether one alias may reference
-     * another
-     * 
+     * Gets whether aliases may chain i.e. whether one alias may reference another
+     *
      * @return True if they can chain, false otherwise
      */
     public boolean aliasesMayChain() {
@@ -156,10 +174,9 @@ public class ParserMetadata<T> {
     }
 
     /**
-     * Gets the prefix character used in alias definitions to indicate that when
-     * resolving an alias that it should force the built-in to be called even if
-     * there is an alias of that name and built-in overriding is enabled
-     * 
+     * Gets the prefix character used in alias definitions to indicate that when resolving an alias that it should force
+     * the built-in to be called even if there is an alias of that name and built-in overriding is enabled
+     *
      * @return Force built in prefix character
      */
     public char getAliasForceBuiltInPrefix() {
@@ -168,7 +185,7 @@ public class ParserMetadata<T> {
 
     /**
      * Gets the option parsers to use
-     * 
+     *
      * @return Option parsers
      */
     public List<OptionParser<T>> getOptionParsers() {
@@ -177,7 +194,7 @@ public class ParserMetadata<T> {
 
     /**
      * Gets whether command/group name abbreviation is allowed
-     * 
+     *
      * @return True if allowed, false otherwise
      */
     public boolean allowsAbbreviatedCommands() {
@@ -186,7 +203,7 @@ public class ParserMetadata<T> {
 
     /**
      * Gets whether option name abbreviation is allowed
-     * 
+     *
      * @return True if allowed, false otherwise
      */
     public boolean allowsAbbreviatedOptions() {
@@ -195,7 +212,7 @@ public class ParserMetadata<T> {
 
     /**
      * Gets the arguments separator to be used
-     * 
+     *
      * @return Arguments separator
      */
     public String getArgumentsSeparator() {
@@ -204,7 +221,7 @@ public class ParserMetadata<T> {
 
     /**
      * Gets whether this configuration allows flag negation
-     * 
+     *
      * @return True if negation is allowed, false otherwise
      */
     public boolean allowsFlagNegation() {
@@ -213,7 +230,7 @@ public class ParserMetadata<T> {
 
     /**
      * Gets the flag negation prefix that is in use (if any)
-     * 
+     *
      * @return Flag negation prefix, may be {@code null} if not enabled
      */
     public String getFlagNegationPrefix() {

--- a/airline-core/src/test/java/com/github/rvesse/airline/CustomModule.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/CustomModule.java
@@ -13,15 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.rvesse.airline.command;
 
-import com.github.rvesse.airline.annotations.AirlineModule;
-import com.github.rvesse.airline.annotations.Command;
+package com.github.rvesse.airline;
 
-@Command(name = "remote",
-         description = "A command whose name is similar to other command names")
-public class CommandRemote {
-    @AirlineModule
-    public CommandMain commandMain;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A custom composition annotation for testing
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface CustomModule {
 
 }

--- a/airline-core/src/test/java/com/github/rvesse/airline/Ping.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/Ping.java
@@ -15,7 +15,7 @@
  */
 package com.github.rvesse.airline;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.HelpOption;
 import com.github.rvesse.airline.SingleCommand;

--- a/airline-core/src/test/java/com/github/rvesse/airline/Ping.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/Ping.java
@@ -15,17 +15,14 @@
  */
 package com.github.rvesse.airline;
 
-import jakarta.inject.Inject;
-
-import com.github.rvesse.airline.HelpOption;
-import com.github.rvesse.airline.SingleCommand;
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 
 @Command(name = "ping", description = "network test utility")
 public class Ping
 {
-    @Inject
+    @AirlineModule
     public HelpOption<Ping> helpOption;
 
     @Option(name = {"-c", "--count"}, description = "Send count packets")

--- a/airline-core/src/test/java/com/github/rvesse/airline/TestGalaxyCommandLineParser.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/TestGalaxyCommandLineParser.java
@@ -15,7 +15,7 @@
  */
 package com.github.rvesse.airline;
 
-import com.github.rvesse.airline.Cli;
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
@@ -26,13 +26,10 @@ import com.github.rvesse.airline.model.CommandMetadata;
 import com.github.rvesse.airline.model.GlobalMetadata;
 import com.github.rvesse.airline.utils.AirlineTestUtils;
 import com.github.rvesse.airline.utils.predicates.parser.CommandFinder;
-
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import jakarta.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -229,7 +226,7 @@ public class TestGalaxyCommandLineParser
 
     public static abstract class GalaxyCommand
     {
-        @Inject
+        @AirlineModule
         public GlobalOptions globalOptions = new GlobalOptions();
 
         public void execute()
@@ -242,7 +239,7 @@ public class TestGalaxyCommandLineParser
     public static class HelpCommand
             extends GalaxyCommand
     {
-        @Inject
+        @AirlineModule
         public Help<GalaxyCommand> help;
 
         @Override
@@ -256,7 +253,7 @@ public class TestGalaxyCommandLineParser
     public static class ShowCommand
             extends GalaxyCommand
     {
-        @Inject
+        @AirlineModule
         public final SlotFilter slotFilter = new SlotFilter();
 
         @Override
@@ -276,7 +273,7 @@ public class TestGalaxyCommandLineParser
         @Option(name = {"--count"}, description = "Number of instances to install")
         public int count = 1;
 
-        @Inject
+        @AirlineModule
         public final AgentFilter agentFilter = new AgentFilter();
 
         @Arguments(description = "The binary and @configuration to install.  The default packaging is tar.gz")
@@ -298,7 +295,7 @@ public class TestGalaxyCommandLineParser
     public static class UpgradeCommand
             extends GalaxyCommand
     {
-        @Inject
+        @AirlineModule
         public final SlotFilter slotFilter = new SlotFilter();
 
         @Arguments(description = "Version of the binary and/or @configuration")
@@ -319,7 +316,7 @@ public class TestGalaxyCommandLineParser
     public static class TerminateCommand
             extends GalaxyCommand
     {
-        @Inject
+        @AirlineModule
         public final SlotFilter slotFilter = new SlotFilter();
 
         @Override
@@ -336,7 +333,7 @@ public class TestGalaxyCommandLineParser
     public static class StartCommand
             extends GalaxyCommand
     {
-        @Inject
+        @AirlineModule
         public final SlotFilter slotFilter = new SlotFilter();
 
         @Override
@@ -353,7 +350,7 @@ public class TestGalaxyCommandLineParser
     public static class StopCommand
             extends GalaxyCommand
     {
-        @Inject
+        @AirlineModule
         public final SlotFilter slotFilter = new SlotFilter();
 
         @Override
@@ -370,7 +367,7 @@ public class TestGalaxyCommandLineParser
     public static class RestartCommand
             extends GalaxyCommand
     {
-        @Inject
+        @AirlineModule
         public final SlotFilter slotFilter = new SlotFilter();
 
         @Override
@@ -387,7 +384,7 @@ public class TestGalaxyCommandLineParser
     public static class ResetToActualCommand
             extends GalaxyCommand
     {
-        @Inject
+        @AirlineModule
         public final SlotFilter slotFilter = new SlotFilter();
 
         @Override
@@ -404,7 +401,7 @@ public class TestGalaxyCommandLineParser
     public static class SshCommand
             extends GalaxyCommand
     {
-        @Inject
+        @AirlineModule
         public final SlotFilter slotFilter = new SlotFilter();
 
         @Arguments(description = "Command to execute on the remote host")
@@ -449,7 +446,7 @@ public class TestGalaxyCommandLineParser
     public static class AgentShowCommand
             extends GalaxyCommand
     {
-        @Inject
+        @AirlineModule
         public final AgentFilter agentFilter = new AgentFilter();
 
         @Override

--- a/airline-core/src/test/java/com/github/rvesse/airline/TestGalaxyCommandLineParser.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/TestGalaxyCommandLineParser.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/airline-core/src/test/java/com/github/rvesse/airline/TestParametersDelegate.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/TestParametersDelegate.java
@@ -15,24 +15,18 @@
  */
 package com.github.rvesse.airline;
 
-import com.github.rvesse.airline.Cli;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
-import com.github.rvesse.airline.utils.AirlineUtils;
-
+import jakarta.inject.Inject;
 import org.testng.annotations.Test;
-
-import javax.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static com.github.rvesse.airline.TestingUtil.singleCommandParser;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 /**
  * @author dain
@@ -130,7 +124,12 @@ public class TestParametersDelegate
             @Option(name = "-c")
             public boolean isC;
 
-            @Inject
+            // Intentionally using old javax.inject.Inject to verify Airline copes with mixtures of old and new @Inject
+            // annotation
+            // Your IDE may complain it can't see this annotation, it comes from shaded repackaging in the
+            // airline-backcompact-javaxinject module to force different Maven coordinates as you can't have multiple
+            // versions of the same Maven coordinates in your dependency tree
+            @javax.inject.Inject
             public NestedDelegate1 nestedDelegate1 = new NestedDelegate1();
         }
 

--- a/airline-core/src/test/java/com/github/rvesse/airline/TestSingleCommand.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/TestSingleCommand.java
@@ -15,50 +15,26 @@
  */
 package com.github.rvesse.airline;
 
-import com.github.rvesse.airline.Cli;
-import com.github.rvesse.airline.HelpOption;
-import com.github.rvesse.airline.SingleCommand;
-import com.github.rvesse.airline.builder.CliBuilder;
-import com.github.rvesse.airline.builder.ParserBuilder;
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
-import com.github.rvesse.airline.args.Args1;
-import com.github.rvesse.airline.args.Args1CustomParser;
-import com.github.rvesse.airline.args.Args2;
-import com.github.rvesse.airline.args.ArgsAllowedValues;
-import com.github.rvesse.airline.args.ArgsArityString;
-import com.github.rvesse.airline.args.ArgsBooleanArity;
-import com.github.rvesse.airline.args.ArgsBooleanArity0;
-import com.github.rvesse.airline.args.ArgsEnum;
-import com.github.rvesse.airline.args.ArgsInherited;
-import com.github.rvesse.airline.args.ArgsMultipleUnparsed;
-import com.github.rvesse.airline.args.ArgsOutOfMemory;
-import com.github.rvesse.airline.args.ArgsPrivate;
-import com.github.rvesse.airline.args.ArgsRequired;
-import com.github.rvesse.airline.args.ArgsRequiredInheritedUnrestricted;
-import com.github.rvesse.airline.args.ArgsSingleChar;
-import com.github.rvesse.airline.args.ArgsSingleCharCustomParser;
-import com.github.rvesse.airline.args.Arity1;
-import com.github.rvesse.airline.args.OptionsRequired;
+import com.github.rvesse.airline.args.*;
+import com.github.rvesse.airline.builder.CliBuilder;
+import com.github.rvesse.airline.builder.ParserBuilder;
 import com.github.rvesse.airline.command.CommandAdd;
 import com.github.rvesse.airline.command.CommandCommit;
 import com.github.rvesse.airline.model.CommandMetadata;
 import com.github.rvesse.airline.model.ParserMetadata;
 import com.github.rvesse.airline.parser.errors.ParseException;
 import com.github.rvesse.airline.parser.errors.ParseOptionGroupException;
-import com.github.rvesse.airline.parser.options.ClassicGetOptParser;
 import com.github.rvesse.airline.parser.options.GreedyClassicGetOptParser;
 import com.github.rvesse.airline.parser.options.StandardOptionParser;
-import com.github.rvesse.airline.utils.AirlineUtils;
 import com.github.rvesse.airline.utils.predicates.parser.CommandFinder;
-
 import org.apache.commons.collections4.CollectionUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import jakarta.inject.Inject;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -66,9 +42,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.github.rvesse.airline.SingleCommand.singleCommand;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class TestSingleCommand {
     @Test
@@ -474,7 +448,7 @@ public class TestSingleCommand {
 
     @Command(name = "test", description = "TestCommand")
     public static class CommandTest {
-        @Inject
+        @AirlineModule
         public HelpOption<CommandTest> helpOption;
 
         @Arguments(description = "Patterns of files to be added")

--- a/airline-core/src/test/java/com/github/rvesse/airline/TestSingleCommand.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/TestSingleCommand.java
@@ -58,7 +58,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import java.math.BigDecimal;
 import java.util.Arrays;

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandAdd.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandAdd.java
@@ -15,7 +15,7 @@
  */
 package com.github.rvesse.airline.command;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandAdd.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandAdd.java
@@ -15,8 +15,7 @@
  */
 package com.github.rvesse.airline.command;
 
-import jakarta.inject.Inject;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
@@ -26,7 +25,7 @@ import java.util.List;
 @Command(name = "add", description = "Add file contents to the index")
 public class CommandAdd
 {
-    @Inject
+    @AirlineModule
     public CommandMain commandMain;
 
     @Arguments(description = "Patterns of files to be added")

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandCommit.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandCommit.java
@@ -15,7 +15,7 @@
  */
 package com.github.rvesse.airline.command;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandCommit.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandCommit.java
@@ -15,8 +15,7 @@
  */
 package com.github.rvesse.airline.command;
 
-import jakarta.inject.Inject;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
@@ -26,7 +25,7 @@ import java.util.List;
 @Command(name = "commit", description = "Record changes to the repository")
 public class CommandCommit
 {
-    @Inject
+    @AirlineModule
     public CommandMain commandMain;
 
     @Arguments(description = "List of files")

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandHighArityOption.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandHighArityOption.java
@@ -17,7 +17,7 @@ package com.github.rvesse.airline.command;
 
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandHighArityOption.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandHighArityOption.java
@@ -15,17 +15,16 @@
  */
 package com.github.rvesse.airline.command;
 
-import java.util.List;
-
-import jakarta.inject.Inject;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 
+import java.util.List;
+
 @Command(name = "cmd", description = "A command with an option that has a high arity option")
 public class CommandHighArityOption {
-	@Inject
+	@AirlineModule
 	public CommandMain commandMain;
 	
 	@Option(name = "--option", description = "An option with high arity", arity = 4)

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemote.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemote.java
@@ -15,7 +15,7 @@
  */
 package com.github.rvesse.airline.command;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Command;
 

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemotes.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemotes.java
@@ -22,9 +22,8 @@ import com.github.rvesse.airline.annotations.Command;
 public class CommandRemotes {
     // Intentionally using old javax.inject.Inject to verify Airline copes with mixtures of old and new @Inject
     // annotation
-    // Your IDE may complain it can't see this annotation, it comes from shaded repackaging in the
-    // airline-backcompact-javaxinject module to force different Maven coordinates as you can't have multiple
-    // versions of the same Maven coordinates in your dependency tree
+    // Your IDE may complain it can't see this annotation, it comes indirectly from the
+    // airline-backcompact-javaxinject module
     @javax.inject.Inject
     public CommandMain commandMain;
 

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemotes.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemotes.java
@@ -22,6 +22,11 @@ import com.github.rvesse.airline.annotations.Command;
 @Command(name = "remotes",
          description = "A command whose name is an extension of another commands name")
 public class CommandRemotes {
+    // Intentionally using old javax.inject.Inject to verify Airline copes with mixtures of old and new @Inject
+    // annotation
+    // Your IDE may complain it can't see this annotation, it comes from shaded repackaging in the
+    // airline-backcompact-javaxinject module to force different Maven coordinates as you can't have multiple
+    // versions of the same Maven coordinates in your dependency tree
     @Inject
     public CommandMain commandMain;
 

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemotes.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemotes.java
@@ -15,8 +15,6 @@
  */
 package com.github.rvesse.airline.command;
 
-import javax.inject.Inject;
-
 import com.github.rvesse.airline.annotations.Command;
 
 @Command(name = "remotes",
@@ -27,7 +25,7 @@ public class CommandRemotes {
     // Your IDE may complain it can't see this annotation, it comes from shaded repackaging in the
     // airline-backcompact-javaxinject module to force different Maven coordinates as you can't have multiple
     // versions of the same Maven coordinates in your dependency tree
-    @Inject
+    @javax.inject.Inject
     public CommandMain commandMain;
 
 }

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemove.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemove.java
@@ -15,15 +15,14 @@
  */
 package com.github.rvesse.airline.command;
 
-import java.util.List;
-
-import jakarta.inject.Inject;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.help.Discussion;
 import com.github.rvesse.airline.annotations.help.Examples;
+
+import java.util.List;
 
 /**
  * <p></p>
@@ -36,7 +35,7 @@ import com.github.rvesse.airline.annotations.help.Examples;
 @Discussion(paragraphs = "More details about how this removes files from the index.")
 @Examples(examples = "$ git remove -i myfile.java", descriptions = "This is a usage example")
 public class CommandRemove {
-    @Inject
+    @AirlineModule
     public CommandMain commandMain;
 
     @Arguments(description = "Patterns of files to be added")

--- a/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemove.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/command/CommandRemove.java
@@ -17,7 +17,7 @@ package com.github.rvesse.airline.command;
 
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Strings.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Strings.java
@@ -15,25 +15,16 @@
  */
 package com.github.rvesse.airline.restrictions;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import jakarta.inject.Inject;
-
 import com.github.rvesse.airline.HelpOption;
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
-import com.github.rvesse.airline.annotations.restrictions.EndsWith;
-import com.github.rvesse.airline.annotations.restrictions.ExactLength;
-import com.github.rvesse.airline.annotations.restrictions.MaxLength;
-import com.github.rvesse.airline.annotations.restrictions.MinLength;
-import com.github.rvesse.airline.annotations.restrictions.NoOptionLikeValues;
-import com.github.rvesse.airline.annotations.restrictions.NotBlank;
-import com.github.rvesse.airline.annotations.restrictions.NotEmpty;
-import com.github.rvesse.airline.annotations.restrictions.Pattern;
-import com.github.rvesse.airline.annotations.restrictions.StartsWith;
+import com.github.rvesse.airline.annotations.restrictions.*;
 import com.github.rvesse.airline.annotations.restrictions.ranges.LengthRange;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Command(name = "strings")
 public class Strings {
@@ -102,7 +93,7 @@ public class Strings {
     @NoOptionLikeValues
     public List<String> args = new ArrayList<>();
     
-    @Inject
+    @AirlineModule
     public HelpOption<Strings> helpOption = new HelpOption<>();
     
 }

--- a/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Strings.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/restrictions/Strings.java
@@ -18,7 +18,7 @@ package com.github.rvesse.airline.restrictions;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.HelpOption;
 import com.github.rvesse.airline.annotations.Arguments;

--- a/airline-examples/pom.xml
+++ b/airline-examples/pom.xml
@@ -19,6 +19,16 @@
       <groupId>com.github.rvesse</groupId>
       <artifactId>airline</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta.inject</groupId>
+          <artifactId>jakarta.inject-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.github.rvesse</groupId>
+          <artifactId>airline-backcompat-javaxinject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.rvesse</groupId>

--- a/airline-examples/pom.xml
+++ b/airline-examples/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.rvesse</groupId>
     <artifactId>airline-parent</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-examples</artifactId>
   <name>Airline - Examples</name>

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/BashCompletion.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/BashCompletion.java
@@ -18,7 +18,7 @@ package com.github.rvesse.airline.examples.cli.commands;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/BashCompletion.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/BashCompletion.java
@@ -15,21 +15,20 @@
  */
 package com.github.rvesse.airline.examples.cli.commands;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-
-import jakarta.inject.Inject;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.examples.ExampleRunnable;
 import com.github.rvesse.airline.help.cli.bash.BashCompletionGenerator;
 import com.github.rvesse.airline.model.GlobalMetadata;
 
+import java.io.FileOutputStream;
+import java.io.IOException;
+
 @Command(name = "generate-completions", description = "Generates a Bash completion script, the file can then be sourced to provide completion for this CLI")
 public class BashCompletion implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private GlobalMetadata<ExampleRunnable> global;
     
     @Option(name = "--include-hidden", description = "When set hidden commands and options are shown in help", hidden = true)

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/Help.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/Help.java
@@ -15,12 +15,7 @@
  */
 package com.github.rvesse.airline.examples.cli.commands;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import jakarta.inject.Inject;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
@@ -29,10 +24,14 @@ import com.github.rvesse.airline.examples.ExampleRunnable;
 import com.github.rvesse.airline.help.cli.bash.CompletionBehaviour;
 import com.github.rvesse.airline.model.GlobalMetadata;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 @Command(name = "help", description = "A command that provides help on other commands")
 public class Help implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private GlobalMetadata<ExampleRunnable> global;
 
     @Arguments(description = "Provides the name of the commands you want to provide help for")

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/Help.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/Help.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/Manuals.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/Manuals.java
@@ -18,7 +18,7 @@ package com.github.rvesse.airline.examples.cli.commands;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/Manuals.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/cli/commands/Manuals.java
@@ -15,11 +15,7 @@
  */
 package com.github.rvesse.airline.examples.cli.commands;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-
-import jakarta.inject.Inject;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.examples.ExampleRunnable;
@@ -27,10 +23,13 @@ import com.github.rvesse.airline.help.man.ManGlobalUsageGenerator;
 import com.github.rvesse.airline.help.man.ManSections;
 import com.github.rvesse.airline.model.GlobalMetadata;
 
+import java.io.FileOutputStream;
+import java.io.IOException;
+
 @Command(name = "generate-manuals", description = "Generates manual pages for this CLI that can be rendered with the man tool")
 public class Manuals implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private GlobalMetadata<ExampleRunnable> global;
 
     @Option(name = "--include-hidden", description = "When set hidden commands and options are shown in help", hidden = true)

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/inheritance/Parent.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/inheritance/Parent.java
@@ -15,7 +15,7 @@
  */
 package com.github.rvesse.airline.examples.inheritance;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.HelpOption;
 import com.github.rvesse.airline.annotations.Command;

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/inheritance/Parent.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/inheritance/Parent.java
@@ -15,9 +15,8 @@
  */
 package com.github.rvesse.airline.examples.inheritance;
 
-import jakarta.inject.Inject;
-
 import com.github.rvesse.airline.HelpOption;
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.examples.ExampleExecutor;
@@ -30,7 +29,7 @@ import com.github.rvesse.airline.examples.ExampleRunnable;
 @Command(name = "parent", description = "A parent command")
 public class Parent implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     protected HelpOption<ExampleRunnable> help;
 
     @Option(name = "--parent", description = "An option provided by the parent")

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/modules/ModuleReuse.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/modules/ModuleReuse.java
@@ -18,7 +18,7 @@ package com.github.rvesse.airline.examples.modules;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/modules/ModuleReuse.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/modules/ModuleReuse.java
@@ -15,18 +15,16 @@
  */
 package com.github.rvesse.airline.examples.modules;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import jakarta.inject.Inject;
-
-import org.apache.commons.lang3.StringUtils;
-
 import com.github.rvesse.airline.HelpOption;
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.examples.ExampleExecutor;
 import com.github.rvesse.airline.examples.ExampleRunnable;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Here we have another command which reuses module classes we've defined and
@@ -38,13 +36,13 @@ import com.github.rvesse.airline.examples.ExampleRunnable;
 @Command(name = "module-reuse", description = "A command that demonstrates re-use of modules and composition with locally defined options")
 public class ModuleReuse implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private HelpOption<ExampleRunnable> help;
 
     /**
-     * A field marked with {@link Inject} will also be scanned for options
+     * A field marked with {@link AirlineModule} will also be scanned for options
      */
-    @Inject
+    @AirlineModule
     private VerbosityModule verbosity = new VerbosityModule();
 
     @Arguments

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/modules/Modules.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/modules/Modules.java
@@ -15,9 +15,8 @@
  */
 package com.github.rvesse.airline.examples.modules;
 
-import jakarta.inject.Inject;
-
 import com.github.rvesse.airline.HelpOption;
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.examples.ExampleExecutor;
 import com.github.rvesse.airline.examples.ExampleRunnable;
@@ -35,19 +34,19 @@ import com.github.rvesse.airline.examples.ExampleRunnable;
 @Command(name = "modules", description = "A command that demonstrates the use of modules to group together sets of options for composition and reuse")
 public class Modules implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private HelpOption<ExampleRunnable> help;
 
     /**
-     * A field marked with {@link Inject} will also be scanned for options
+     * A field marked with {@link AirlineModule} will also be scanned for options
      */
-    @Inject
+    @AirlineModule
     public CredentialsModule credentials = new CredentialsModule();
 
     /**
-     * A field marked with {@link Inject} will also be scanned for options
+     * A field marked with {@link AirlineModule} will also be scanned for options
      */
-    @Inject
+    @AirlineModule
     public VerbosityModule verbosity = new VerbosityModule();
 
     public static void main(String[] args) {

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/modules/Modules.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/modules/Modules.java
@@ -15,7 +15,7 @@
  */
 package com.github.rvesse.airline.examples.modules;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.HelpOption;
 import com.github.rvesse.airline.annotations.Command;

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/CheckAddress.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/CheckAddress.java
@@ -15,7 +15,7 @@
  */
 package com.github.rvesse.airline.examples.sendit;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.examples.ExampleRunnable;

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/CheckAddress.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/CheckAddress.java
@@ -15,15 +15,14 @@
  */
 package com.github.rvesse.airline.examples.sendit;
 
-import jakarta.inject.Inject;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.examples.ExampleRunnable;
 
 @Command(name = "check-address", description = "Check if an address meets our restrictions")
 public class CheckAddress implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private PostalAddress address = new PostalAddress();
 
     @Override

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/Price.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/Price.java
@@ -15,7 +15,7 @@
  */
 package com.github.rvesse.airline.examples.sendit;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/Price.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/Price.java
@@ -15,8 +15,7 @@
  */
 package com.github.rvesse.airline.examples.sendit;
 
-import jakarta.inject.Inject;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.examples.ExampleRunnable;
@@ -28,7 +27,7 @@ public class Price implements ExampleRunnable {
             "--service" }, title = "Service", description = "Specifies the postal service you would like to use")
     private PostalService service = PostalService.FirstClass;
 
-    @Inject
+    @AirlineModule
     private Package item = new Package();
 
     @Override

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/Send.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/Send.java
@@ -15,7 +15,7 @@
  */
 package com.github.rvesse.airline.examples.sendit;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.SingleCommand;
 import com.github.rvesse.airline.annotations.Command;

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/Send.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/sendit/Send.java
@@ -15,9 +15,8 @@
  */
 package com.github.rvesse.airline.examples.sendit;
 
-import jakarta.inject.Inject;
-
 import com.github.rvesse.airline.SingleCommand;
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.examples.ExampleRunnable;
@@ -26,10 +25,10 @@ import com.github.rvesse.airline.parser.errors.ParseException;
 @Command(name = "send", description = "Sends a package")
 public class Send implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private PostalAddress address = new PostalAddress();
 
-    @Inject
+    @AirlineModule
     private Package item = new Package();
 
     @Option(name = { "-s",

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/simple/Simple.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/simple/Simple.java
@@ -17,7 +17,7 @@ package com.github.rvesse.airline.examples.simple;
 
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/simple/Simple.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/simple/Simple.java
@@ -15,18 +15,16 @@
  */
 package com.github.rvesse.airline.examples.simple;
 
-import java.util.List;
-
-import jakarta.inject.Inject;
-
-import org.apache.commons.lang3.StringUtils;
-
 import com.github.rvesse.airline.HelpOption;
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.examples.ExampleExecutor;
 import com.github.rvesse.airline.examples.ExampleRunnable;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
 
 /**
  * A simple example that demonstrates most of the basic concepts
@@ -49,7 +47,7 @@ public class Simple implements ExampleRunnable {
      * the user requested the help
      * </p>
      */
-    @Inject
+    @AirlineModule
     private HelpOption<Simple> help;
 
     @Option(name = { "-f", "--flag" }, description = "An option that requires no arguments")

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/userguide/help/sections/Discussed.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/userguide/help/sections/Discussed.java
@@ -16,11 +16,7 @@
 
 package com.github.rvesse.airline.examples.userguide.help.sections;
 
-import java.io.IOException;
-import java.util.List;
-
-import jakarta.inject.Inject;
-
+import com.github.rvesse.airline.annotations.AirlineModule;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.help.Discussion;
@@ -28,6 +24,9 @@ import com.github.rvesse.airline.examples.ExampleExecutor;
 import com.github.rvesse.airline.examples.ExampleRunnable;
 import com.github.rvesse.airline.help.Help;
 import com.github.rvesse.airline.model.CommandMetadata;
+
+import java.io.IOException;
+import java.util.List;
 
 @Command(name = "discussed", description = "A command with a discussion section")
 //@formatter:off
@@ -39,7 +38,7 @@ import com.github.rvesse.airline.model.CommandMetadata;
 //@formatter:on
 public class Discussed implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private CommandMetadata metadata;
     
     @Arguments

--- a/airline-examples/src/main/java/com/github/rvesse/airline/examples/userguide/help/sections/Discussed.java
+++ b/airline-examples/src/main/java/com/github/rvesse/airline/examples/userguide/help/sections/Discussed.java
@@ -19,7 +19,7 @@ package com.github.rvesse.airline.examples.userguide.help.sections;
 import java.io.IOException;
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;

--- a/airline-help/airline-help-bash/pom.xml
+++ b/airline-help/airline-help-bash/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.rvesse</groupId>
     <artifactId>airline-help</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-help-bash</artifactId>
   <name>Airline - Help - Bash</name>

--- a/airline-help/airline-help-html/pom.xml
+++ b/airline-help/airline-help-html/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.rvesse</groupId>
     <artifactId>airline-help</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-help-html</artifactId>
   <name>Airline - Help - HTML</name>

--- a/airline-help/airline-help-man/pom.xml
+++ b/airline-help/airline-help-man/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.rvesse</groupId>
     <artifactId>airline-help</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-help-man</artifactId>
   <name>Airline - Help - Man Page (Troff)</name>

--- a/airline-help/airline-help-markdown/pom.xml
+++ b/airline-help/airline-help-markdown/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.rvesse</groupId>
     <artifactId>airline-help</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-help-markdown</artifactId>
   <name>Airline - Help - Markdown</name>

--- a/airline-help/pom.xml
+++ b/airline-help/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.rvesse</groupId>
     <artifactId>airline-parent</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-help</artifactId>
   <packaging>pom</packaging>

--- a/airline-io/pom.xml
+++ b/airline-io/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.rvesse</groupId>
     <artifactId>airline-parent</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-io</artifactId>
   <name>Airline - IO Library</name>

--- a/airline-maven-plugin/pom.xml
+++ b/airline-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>airline-parent</artifactId>
     <groupId>com.github.rvesse</groupId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>airline-maven-plugin</artifactId>

--- a/airline-maven-plugin/src/main/java/com/github/rvesse/airline/maven/Source.java
+++ b/airline-maven-plugin/src/main/java/com/github/rvesse/airline/maven/Source.java
@@ -52,7 +52,7 @@ public class Source {
             try {
                 Class<?> cls = getClass().getClassLoader().loadClass(className);
                 if (cls.getAnnotation(Command.class) != null) {
-                    prepared.add(new PreparedSource(cls, null, MetadataLoader.loadCommand(cls), this.options,
+                    prepared.add(new PreparedSource(cls, null, MetadataLoader.loadCommand(cls, MetadataLoader.loadParser(cls)), this.options,
                             this.outputMode));
                 } else if (cls.getAnnotation(Cli.class) != null) {
                     prepared.add(new PreparedSource(cls, MetadataLoader.loadGlobal(cls), null, this.options,

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,7 +26,7 @@ author:
 
 # Custom vars
 version:          2.8.5
-dev_version:	"2.8.6-SNAPSHOT"
+dev_version:	"2.9.0-SNAPSHOT"
 
 github:
   repo:           https://github.com/rvesse/airline

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -14,6 +14,7 @@
     	  	    <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/command.html">@Command</a></li>
             	<li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/option.html">@Option</a></li>
   	  	      <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/arguments.html">@Arguments</a></li>
+              <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/module.html">@AirlineModule</a></li>
    	  	      <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/cli.html">@Cli</a></li>
    	  	      <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/group.html">@Group</a></li>
   	  	      <li><a class="sidebar-nav-item" href="{{ site.baseurl }}/guide/annotations/groups.html">@Groups</a></li>

--- a/docs/guide/annotations/module.md
+++ b/docs/guide/annotations/module.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: AirlineModule Annotation
+---
+
+{% include req-ver.md version="2.9.0" %}
+
+## `@AirlineModule`
+
+The `@AirlineModule` annotation is applied to fields to indicate that their value types should also be inspected to
+discover further Airline metadata e.g. [`@Option`](option.html) and [`@Arguments`](arguments.html) annotated fields
+that are used to define a command.
+
+This is used to enable Airline's [Composition](../practise/oop.html#composition) mechanism that allows common 
+definitions of options and arguments to be shared across multiple command classes without using inheritance.
+
+For a practical example of this annotation in use see the [`HelpOption`](../help/index.html#helpoption) that is used
+to provide a `-h`/`--help` option to other commands.

--- a/docs/guide/annotations/parser.md
+++ b/docs/guide/annotations/parser.md
@@ -5,34 +5,47 @@ title: Parser Annotation
 
 ## `@Parser`
 
-The `@Parser` annotation is applied to classes also annotated with `@Command` to configure the parser behaviour for that single command when parsers are created using `SingleCommand.singleCommand()`.
+The `@Parser` annotation is applied to classes also annotated with `@Command` to configure the parser behaviour for that
+single command when parsers are created using `SingleCommand.singleCommand()`.
 
-It may also be used as an argument to the [`@Cli`](cli.html) annotation in order to configure parser behaviour for a CLI via the `parserConfiguration` field of that annotation.
+It may also be used as an argument to the [`@Cli`](cli.html) annotation in order to configure parser behaviour for a CLI
+via the `parserConfiguration` field of that annotation.
 
 ### Default Configuration
 
-To get the default parser configuration you do not need to specify any fields on the annotation i.e. simply provide a basic annotation:
+To get the default parser configuration you do not need to specify any fields on the annotation i.e. simply provide a
+basic annotation:
 
 ```java
 @Parser()
 ```
 
-This has the same effect as not specifying any parser configuration since in that case Airline will use its defaults which are sufficient for most basic uses.
+This has the same effect as not specifying any parser configuration since in that case Airline will use its defaults
+which are sufficient for most basic uses.
 
 ### Option Parsers
 
-[Option Parsers](../parser/options.html) are used to control how Airline parses options, Airline comes with a variety of implementations of these and there are several fields of the `@Parser` annotation that are used to configure these.
+[Option Parsers](../parser/options.html) are used to control how Airline parses options, Airline comes with a variety of
+implementations of these and there are several fields of the `@Parser` annotation that are used to configure these.
 
-Firstly there are the `useDefaultOptionParsers` and `defaultParsersFirst` fields, the former indicates that the default set of option parsers should be used and the latter indicates whether the defaults are configured before/after any other option parsers that you might configure.  Both of these default to `true` so there is no need to specify either unless you want to disable the default parsers or use alternative parsers in preference to the defaults e.g.
+Firstly there are the `useDefaultOptionParsers` and `defaultParsersFirst` fields, the former indicates that the default
+set of option parsers should be used and the latter indicates whether the defaults are configured before/after any other
+option parsers that you might configure.  Both of these default to `true` so there is no need to specify either unless
+you want to disable the default parsers or use alternative parsers in preference to the defaults e.g.
 
 ```java
 @Parser(useDefaultOptionParsers = true, 
         defaultParsersFirst = false)
 ```
 
-The `optionParsers` field is used to provide an array of classes that implement the `OptionParser` interface and thus can be used to customise the option parsers used or to change the order in which they are used.
+The `optionParsers` field is used to provide an array of classes that implement the `OptionParser` interface and thus
+can be used to customise the option parsers used or to change the order in which they are used.
 
-For example with the default parsers if we had an option that had arity 2 with the default parsers the user would be expected to specify it as `--option foo bar`.  However often in reality if we have an arity 2 argument we are expecting users to pass in a pair of values and it is quite common to do this as `--option foo=bar` which with the default configuration would be an error.  If we wanted to enable this style of parsing we could do so by enabling the built-in `MaybePairValueOptionParser` e.g.
+For example with the default parsers if we had an option that had arity 2 with the default parsers the user would be
+expected to specify it as `--option foo bar`.  However often in reality if we have an arity 2 argument we are expecting
+users to pass in a pair of values and it is quite common to do this as `--option foo=bar` which with the default
+configuration would be an error.  If we wanted to enable this style of parsing we could do so by enabling the built-in
+`MaybePairValueOptionParser` e.g.
 
 ```java
 @Parser(defaultParsersFirst = false, 
@@ -41,7 +54,8 @@ For example with the default parsers if we had an option that had arity 2 with t
 
 ### Type Converter
 
-If we wanted to use a custom type converter as detailed in [Supported Types](../practise/types.html) then we can use the `typeConverter` field to do this e.g.
+If we wanted to use a custom type converter as detailed in [Supported Types](../practise/types.html) then we can use the
+`typeConverter` field to do this e.g.
 
 ```java
 @Parser(typeConverter = ExtendedTypeConverter.class)
@@ -50,24 +64,30 @@ The provided class must implement the `TypeConverter` interface.
 
 #### Numeric Type Converter
 
-If we wanted to customise how numeric values are converted as detailed in [Supported Types](../practise/types.html) then we can use the `numericTypeConverter` field to do this e.g.
+If we wanted to customise how numeric values are converted as detailed in [Supported Types](../practise/types.html) then
+we can use the `numericTypeConverter` field to do this e.g.
 
 ```java
 @Parser(numericTypeConverter = KiloAs1000.class)
 ```
 The provided class must implement the `NumericTypeConverter` interface.
 
-In this example the numeric type converter is set to use the built-in `KiloAs1000` numeric converter which allows for users to abbreviate numbers e.g. `4k` would be converted to `4000`
+In this example the numeric type converter is set to use the built-in `KiloAs1000` numeric converter which allows for
+users to abbreviate numbers e.g. `4k` would be converted to `4000`
 
 ### Boolean Flag Negation
 
-Often when using flag arguments i.e. those with `boolean` type and arity zero it is useful to allow users to specify both a positive and negative version of the flag.  For example we might want to have `--overwrite` and `--no-overwrite`.  In order to do this we need to define an option that has both versions present in its `name` array and set a `flagNegationPrefix` on our parser:
+Often when using flag arguments i.e. those with `boolean` type and arity zero it is useful to allow users to specify
+both a positive and negative version of the flag.  For example we might want to have `--overwrite` and `--no-overwrite`.
+In order to do this we need to define an option that has both versions present in its `name` array and set a
+`flagNegationPrefix` on our parser:
 
 ```java
 @Parser(flagNegationPrefix = "--no-")
 ```
 
-Now if a boolean arity zero option is used and its name starts with `--no-` then the parser will set its value to `false`, if the name does not start with the configured prefix then it will be set to `true` as usual.
+Now if a boolean arity zero option is used and its name starts with `--no-` then the parser will set its value to
+`false`, if the name does not start with the configured prefix then it will be set to `true` as usual.
 
 This behaviour is off by default and must be explicitly enabled.
 
@@ -79,23 +99,48 @@ If we wanted to use a custom command factory then we can use the `commandFactory
 @Parser(commandFactory = ExtendedCommandFactory.class)
 ```
 
+### Composition Annotations
+
+{% include req-ver.md version="2.9.0" %}
+
+Per the [Composition](../practise/oop.html#composition) documentation Airline will further inspect fields on command
+classes marked with the [`@AirlineModule`](module.html) annotation to discover additional metadata that may have been
+composed into separate classes for reuse.  Which annotations are followed for this is controlled via the
+`compositionAnnotationClasses` field e.g.
+
+```java
+@Parser(compositionAnnotationClasses = { "my.custom.Annotation" })
+```
+
+This takes a list of strings, which are the canonical class names of the annotations you want to consider.  Note that we
+intentionally use strings rather than `Class` objects here so that the annotation type in question does not necessarily
+need to be present on the classpath at runtime.  This is primarily a backwards compatibility feature for users of older
+versions of Airline as discussed in [Historical Composition](../practise/oop.html#historical-composition).
+
 ### Option and Command Abbreviation
 
-Option and command abbreviation is an advanced feature of the Airline parser that allows users to avoid typing the full option and/or command names provided that the portion they type is unambiguous.
+Option and command abbreviation is an advanced feature of the Airline parser that allows users to avoid typing the full
+option and/or command names provided that the portion they type is unambiguous.
 
-For example say we had a CLI which contained a `remove` and a `replace` command, by default users always have to type the full command name.  However if we enable `allowCommandAbbreviation` then users only need to type enough characters to unambiguously identify the command e.g.
+For example say we had a CLI which contained a `remove` and a `replace` command, by default users always have to type
+the full command name.  However if we enable `allowCommandAbbreviation` then users only need to type enough characters
+to unambiguously identify the command e.g.
 
 ```java
 @Parser(allowCommandAbbreviation = true)
 ```
 
-With that enabled a user can now type `rem` for `remove` and `rep` for `replace`, since the abbreviation must be unambiguous typing `re` would not be acceptable as it could refer to either command.
+With that enabled a user can now type `rem` for `remove` and `rep` for `replace`, since the abbreviation must be
+unambiguous typing `re` would not be acceptable as it could refer to either command.
 
-Similarly we can allow the same for option names via the `allowOptionAbbreviation`, option abbreviation is slightly more restrictive in that at least 3 characters must be typed i.e. short names such as `-a` can never be abbreviated.
+Similarly we can allow the same for option names via the `allowOptionAbbreviation`, option abbreviation is slightly more
+restrictive in that at least 3 characters must be typed i.e. short names such as `-a` can never be abbreviated.
 
 ### Arguments Separator
 
-By default Airline supports a separator of `--` which can be used to separate options from arguments where arguments may be misinterpreted as options.  After this separator is seen any further command line arguments are treated as arguments and not as options.
+By default Airline supports a separator of `--` which can be used to separate options from arguments where arguments may
+be misinterpreted as options.  After this separator is seen any further command line arguments are treated as arguments
+and not as options.
 
 If you wish to customise the separator then you can this like so:
 
@@ -107,9 +152,11 @@ Would instead use `@@` as the arguments separator.
 
 ### Aliases
 
-Airline supports a [User Defined Aliases](../practise/aliases.html) system which allows for users to define custom aliases for use with your Airline powered CLIs.
+Airline supports a [User Defined Aliases](../practise/aliases.html) system which allows for users to define custom
+aliases for use with your Airline powered CLIs.
 
-To specify where to get user defined aliases from you use some combination of the `userAliasesFile`, `userAliasesSearchLocation`, and the `userAliasesPrefix` fields e.g.
+To specify where to get user defined aliases from you use some combination of the `userAliasesFile`,
+`userAliasesSearchLocation`, and the `userAliasesPrefix` fields e.g.
 
 ```java
 @Parser(userAliasesFile = "example.config",
@@ -117,9 +164,14 @@ To specify where to get user defined aliases from you use some combination of th
         userAliasesPrefix = "alias.")
 ```
 
-Here we define that aliases will be defined in a file `example.config` which should be found under `~/example` (where `~` is treated as special value for users home directory).
+Here we define that aliases will be defined in a file `example.config` which should be found under `~/example` (where
+`~` is treated as special value for users home directory).
 
-The treatment of special values is controlled by the choice of [Resource Locators](../practise/resource-locators.html) which can be changed via the `userAliasLocators` property.  The use of the default setup, which includes support for `~/` as a reference to the users home directory, is controlled via the `useDefaultAliasLocators` field and `defaultAliasLocatorsFirst`.  For example if we wished to enable use of an environment variable to locate user aliases we could do the following:
+The treatment of special values is controlled by the choice of [Resource Locators](../practise/resource-locators.html)
+which can be changed via the `userAliasLocators` property.  The use of the default setup, which includes support for
+`~/` as a reference to the users home directory, is controlled via the `useDefaultAliasLocators` field and
+`defaultAliasLocatorsFirst`.  For example if we wished to enable use of an environment variable to locate user aliases
+we could do the following:
 
 ```java
 @Parser(userAliasesFile = "example.config",
@@ -130,11 +182,16 @@ The treatment of special values is controlled by the choice of [Resource Locator
         userAliasLocators = { EnvVarLocator.class })
 ```
 
-Here we add a new search location `${EXAMPLE_CONFIG_DIR}` and we configure the use of the `EnvVarLocator` which understands how to resolve that location.  We prefer our configured locators so the environment variable location, if set and resolved, will be the first used.
+Here we add a new search location `${EXAMPLE_CONFIG_DIR}` and we configure the use of the `EnvVarLocator` which
+understands how to resolve that location.  We prefer our configured locators so the environment variable location, if
+set and resolved, will be the first used.
 
 #### Alias Definition Controls
 
-If you are using aliases then there are two remaining options that you may also be interested in.  The `aliasesMayChain` field which defaults to `false` controls whether user defined aliases are allowed to reference each other i.e. whether users can define aliases in terms or other aliases.  When set to `true` then aliases may be defined in terms of each other provided that a circular reference does not exist.
+If you are using aliases then there are two remaining options that you may also be interested in.  The `aliasesMayChain`
+field which defaults to `false` controls whether user defined aliases are allowed to reference each other i.e. whether
+users can define aliases in terms or other aliases.  When set to `true` then aliases may be defined in terms of each
+other provided that a circular reference does not exist.
 
 ```java
 @Parser(userAliasesFile = "example.config",
@@ -143,7 +200,11 @@ If you are using aliases then there are two remaining options that you may also 
         aliasesMayChain = true)
 ```
 
-You can use the `aliasesOverrideBuiltIns` field to control whether user defined aliases are allowed to override built-in commands and this also defaults to false.  To understand this consider that you had defined a command `test` and then a user defines an alias `test` - which version should Airline use?  By default Airline will defer to the built-in command, however in some cases you may want to allow the users alias to take precedence in which case you can set this field to `true` e.g.
+You can use the `aliasesOverrideBuiltIns` field to control whether user defined aliases are allowed to override built-in
+commands and this also defaults to false.  To understand this consider that you had defined a command `test` and then a
+user defines an alias `test` - which version should Airline use?  By default Airline will defer to the built-in command,
+however in some cases you may want to allow the users alias to take precedence in which case you can set this field to
+`true` e.g.
 
 ```java
 @Parser(userAliasesFile = "example.config",
@@ -152,7 +213,8 @@ You can use the `aliasesOverrideBuiltIns` field to control whether user defined 
         aliasesOverrideBuiltIns = true)
 ```
 
-Finally if you want to provide some pre-defined aliases you can do so via the `aliases` property which takes an array of [`@Alias`](alias.html) annotations e.g.
+Finally if you want to provide some pre-defined aliases you can do so via the `aliases` property which takes an array of
+[`@Alias`](alias.html) annotations e.g.
 
 ```java
 @Parser(aliases = {

--- a/docs/guide/help/index.md
+++ b/docs/guide/help/index.md
@@ -3,31 +3,40 @@ layout: page
 title: Help System
 ---
 
-Airline provides a comprehensive system of help generators that are able to take Airline defined CLIs and output help in a variety of formats.  The help system is divided into a number of concepts which cooperate together to make help configurable and extensible.
+Airline provides a comprehensive system of help generators that are able to take Airline defined CLIs and output help in
+a variety of formats.  The help system is divided into a number of concepts which cooperate together to make help
+configurable and extensible.
 
 ### Concepts
 
 #### Help Hints
 
-[Help Hints](hints.html) are a mechanism by which [Restrictions](../restrictions/index.html) can provide information about their behaviour. This allows for restrictions to be self-documenting and incorporated into help output.
+[Help Hints](hints.html) are a mechanism by which [Restrictions](../restrictions/index.html) can provide information
+about their behaviour. This allows for restrictions to be self-documenting and incorporated into help output.
 
 Hints are also used as part of Help Sections.
 
 #### Help Sections
 
-[Help Sections](sections.html) are a mechanism by which [`@Command`](../annotations/command.html) annotated classes can add additional sections into help output. This can be used to incorporate arbitrary additional content into your help outputs.
+[Help Sections](sections.html) are a mechanism by which [`@Command`](../annotations/command.html) annotated classes can
+add additional sections into help output. This can be used to incorporate arbitrary additional content into your help
+outputs.
 
-A variety of common help sections are provided out of the box and you can create [Custom Help Sections](custom-sections.html) if desired:
+A variety of common help sections are provided out of the box and you can create [Custom Help
+Sections](custom-sections.html) if desired:
 
 {% include help-sections.md path="../annotations/" %}
 
 #### Help Generators
 
-[Help Generators](generators.html) are classes that take in CLI/Command metadata and output help in some format.  The core library includes [Text](text.html) based help generators and additional libraries provide [Markdown](markdown.html), [HTML](html.html), [MAN](man.html) and [Bash](bash.html) format help.
+[Help Generators](generators.html) are classes that take in CLI/Command metadata and output help in some format.  The
+core library includes [Text](text.html) based help generators and additional libraries provide
+[Markdown](markdown.html), [HTML](html.html), [MAN](man.html) and [Bash](bash.html) format help.
 
 ### Generating Help
 
-In order to generate help you need to create an instance of your desired generator and then pass in the metadata for your CLI/Command e.g.
+In order to generate help you need to create an instance of your desired generator and then pass in the metadata for
+your CLI/Command e.g.
 
 ```java
    Cli<ExampleRunnable> cli = new Cli<ExampleRunnable>(ShipItCli.class);
@@ -46,7 +55,8 @@ For single commands we could use `CliCommandUsageGenerator` instead.
 
 ### Incorporating Help into your CLI
 
-Airline provides a couple of ways you can incorporate help into your CLIs/commands to make this easily accessible to your end users.
+Airline provides a couple of ways you can incorporate help into your CLIs/commands to make this easily accessible to
+your end users.
 
 #### `HelpOption`
 
@@ -56,7 +66,7 @@ For single commands you can add the `HelpOption` to your command classes e.g.
 @Command(name = "parent", description = "A parent command")
 public class Parent implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     protected HelpOption<ExampleRunnable> help;
 
     @Option(name = "--parent", description = "An option provided by the parent")
@@ -77,13 +87,21 @@ public class Parent implements ExampleRunnable {
 }
 ```
 
-We use our normal [Composition](../practise/oop.html) mechanism to add in `HelpOption` to our command class.  This will provide a `-h`/`--help` option in our command.  We can then use the `help.showHelpIfRequested()` method to check whether help was requested and if not proceed normally.  If this method returns `true` then help has been requested and output to the user.
+We use our normal [Composition](../practise/oop.html) mechanism to add in `HelpOption` to our command class.  This will
+provide a `-h`/`--help` option in our command.  We can then use the `help.showHelpIfRequested()` method to check whether
+help was requested and if not proceed normally.  If this method returns `true` then help has been requested and output
+to the user.
 
 #### `Help` class
 
-The `Help` class is a pre-built `@Command` class that provides intelligent help for CLIs.  You can simply add this to your CLIs as one of your commands and it will add a `help` command to your CLI.  This command will select the appropriate help to display depending on the arguments provided.  For example calling `your-cli help` will display help for the entire CLI, whereas calling `your-cli help your-command` will display command specific help for `your-command`.
+The `Help` class is a pre-built `@Command` class that provides intelligent help for CLIs.  You can simply add this to
+your CLIs as one of your commands and it will add a `help` command to your CLI.  This command will select the
+appropriate help to display depending on the arguments provided.  For example calling `your-cli help` will display help
+for the entire CLI, whereas calling `your-cli help your-command` will display command specific help for `your-command`.
 
-If you can't incorporate `Help` directly as a command because it does not extend/implement the base command type for your CLI you can still use it indirectly.  If you are using a base interface then you can simply extend the class and add `implements YourInterface` plus any necessary implementation deferring to the `run()` method e.g.
+If you can't incorporate `Help` directly as a command because it does not extend/implement the base command type for
+your CLI you can still use it indirectly.  If you are using a base interface then you can simply extend the class and
+add `implements YourInterface` plus any necessary implementation deferring to the `run()` method e.g.
 
 ```java
 
@@ -95,13 +113,15 @@ public class CustomHelpCommand extends Help implements YourInterface {
 }
 ```
 
-Alternatively the class also provides a number of static methods that you can call from your own command if you can't extend it, for example when using a base class for your commands, e.g.
+Alternatively the class also provides a number of static methods that you can call from your own command if you can't
+extend it, for example when using a base class for your commands, e.g.
 
 ```java
 Help.help(cli.getMetadata(), args, System.out)
 ```
 
-Where `args` is a `List<String>` containing the command name(s) that help is being requested on.  So for our earlier example we might call the following:
+Where `args` is a `List<String>` containing the command name(s) that help is being requested on.  So for our earlier
+example we might call the following:
 
 ```java
 Help.help(cli.getMetadata(), Collections.singletonList("your-command"), System.out)
@@ -109,6 +129,9 @@ Help.help(cli.getMetadata(), Collections.singletonList("your-command"), System.o
 
 #### Help and Errors
 
-Note that when trying to incorporate help into a CLI one common problem that occurs is that you add restrictions which end up get violated when users try to just invoke help on your commands.  This is particularly the case when using `HelpOption`.  To avoid this you will need to customise the error handler as discussed in the [Error Handling](../practise/exceptions.html) documentation and do something like the following:
+Note that when trying to incorporate help into a CLI one common problem that occurs is that you add restrictions which
+end up get violated when users try to just invoke help on your commands.  This is particularly the case when using
+`HelpOption`.  To avoid this you will need to customise the error handler as discussed in the [Error
+Handling](../practise/exceptions.html) documentation and do something like the following:
 
 {% include code/error-handler.md %}

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -9,7 +9,10 @@ title: Introduction to Airline
 
 Welcome to the Airline Users Guide, this guide is intended to show you how to use every aspect of Airline.
 
-Many of the examples contained in this user guide may be found in compilable form in our Git repository at <a href="{{ site.github.repo }}/tree/master/airline-examples/src/main/java/com/github/rvesse/airline/examples/userguide">GitHub</a>.  If you have the code checked out and compiled locally you can use the provided `runExamples` script to launch an example e.g.
+Many of the examples contained in this user guide may be found in compilable form in our Git repository at <a href="{{
+site.github.repo }}/tree/master/airline-examples/src/main/java/com/github/rvesse/airline/examples/userguide">GitHub</a>.
+If you have the code checked out and compiled locally you can use the provided `runExamples` script to launch an example
+e.g.
 
 ```
 airline-examples> ./runExample GettingStarted
@@ -22,28 +25,36 @@ Throughout this website where you see a box like the following:
 Some warning text goes here...
 {% include end-alert.html %}
 
-This is a warning that describes a potential pit-fall that users might encounter.  These are used to call out places where it is possible for users to introduce dangerous behaviours, or where they are strict constraints they must respect.
+This is a warning that describes a potential pit-fall that users might encounter.  These are used to call out places
+where it is possible for users to introduce dangerous behaviours, or where they are strict constraints they must
+respect.
 
 Also where the library has evolved over time you may see the following:
 
-{% include req-ver.md version="1.2.3" %}
+{% include req-ver.md version="2.4.5" %}
 
-This is used to denote features that are only available in newer versions of the library or where behaviours have changed across versions.
+This is used to denote features that are only available in newer versions of the library or where behaviours have
+changed across versions.
 
 ## Definitions
 
-Before you get started reading this guide it is useful to introduce the terminology that Airline uses to make sure you are clear what we are referring to.
+Before you get started reading this guide it is useful to introduce the terminology that Airline uses to make sure you
+are clear what we are referring to.
 
 - **Command Line Interface (CLI)**  
   A Command Line Interface (CLI) is a collection of commands potentially grouped into hierarchical groupings.  `git` is a popular example of a CLI
 - **Command**  
-  A command is a single tool that is invoked by a user, a command may appear within multiple groups within a CLI and take a variety of options and arguments
+  A command is a single tool that is invoked by a user, a command may appear within multiple groups within a CLI and
+  take a variety of options and arguments
 - **Command Group**  
-  A command group is a collection of commands within a CLI identified by a name.  Groups may themselves contain other groups to create hierarchies of commands. `git remote` is an example of a group within a CLI
+  A command group is a collection of commands within a CLI identified by a name.  Groups may themselves contain other
+  groups to create hierarchies of commands. `git remote` is an example of a group within a CLI
 - **Option**  
-  An option is a combination of an identifying name e.g. `--name` followed by zero or more values that are used to populate a field of a command, for example `--name Example`
+  An option is a combination of an identifying name e.g. `--name` followed by zero or more values that are used to
+  populate a field of a command, for example `--name Example`
 - **Arguments**  
-  Arguments are any values passed to a command that are not otherwise interpreted i.e. they do not represent options, for example `Example`
+  Arguments are any values passed to a command that are not otherwise interpreted i.e. they do not represent options,
+  for example `Example`
 - **Restriction**  
   A restriction is a constraint placed upon a CLI, options and/or arguments e.g. marking an option as required
 
@@ -51,15 +62,23 @@ Before you get started reading this guide it is useful to introduce the terminol
 
 When talking about CLI parsing libraries people typically talk about three phases.
 
-Firstly there is the **Definition Phase** in which you define your CLI i.e. command groups, commands, options, arguments, restrictions etc.  In Airline the definition phase is done primarily through the use of declarative annotations, you can also do parts of the definition phase using imperative code but it is usually much easier to just rely on declarative annotations.
+Firstly there is the **Definition Phase** in which you define your CLI i.e. command groups, commands, options,
+arguments, restrictions etc.  In Airline the definition phase is done primarily through the use of declarative
+annotations, you can also do parts of the definition phase using imperative code but it is usually much easier to just
+rely on declarative annotations.
 
-Secondly there is the **Parsing Phase** in which you create and run a parser.  Since Airline relies on a declarative annotation based approach to the **Definition Phase** the parsing phase is very simple since you can have Airline generate a parser from your class and then run that parser in as little as two lines of code.
+Secondly there is the **Parsing Phase** in which you create and run a parser.  Since Airline relies on a declarative
+annotation based approach to the **Definition Phase** the parsing phase is very simple since you can have Airline
+generate a parser from your class and then run that parser in as little as two lines of code.
 
-Finally there is the **Interrogation Phase** in which you look at the results of the parser and run your command accordingly.  With Airline the result of the parser is an instance of a Java class/interface with appropriately populated fields and so you can simply access these fields as desired.
+Finally there is the **Interrogation Phase** in which you look at the results of the parser and run your command
+accordingly.  With Airline the result of the parser is an instance of a Java class/interface with appropriately
+populated fields and so you can simply access these fields as desired.
 
 ## Requirements
 
-In order to use Airline in your applications you will need to add a dependency on the `airline` library to your project at a minimum.  Assuming a Maven project you can do this like so:
+In order to use Airline in your applications you will need to add a dependency on the `airline` library to your project
+at a minimum.  Assuming a Maven project you can do this like so:
 
 ```xml
 <dependency>
@@ -71,7 +90,8 @@ In order to use Airline in your applications you will need to add a dependency o
 
 Where `X.Y.Z` is your desired version, the current stable release is `{{ site.version }}`
 
-If you want to use some of the other features Airline provides then you may also need to add additional dependencies to grab additional features.
+If you want to use some of the other features Airline provides then you may also need to add additional dependencies to
+grab additional features.
 
 ## Your First Command
 
@@ -81,15 +101,20 @@ Let's take a look at `GettingStarted.java`:
 
 {% include code/getting-started.md %}
 
-We'll talk about each of the things introduced in the subsequent sections and provide links to more in-depth pages where you can explore each introduced concept in detail.
+We'll talk about each of the things introduced in the subsequent sections and provide links to more in-depth pages where
+you can explore each introduced concept in detail.
 
 ### Definition Phase
 
-The definition phase in Airline is driven primarily through the use of annotations on classes and their fields.  99% of the time you can define your desired CLI entirely through annotations, on the rare occasion where this is not the case you can define some portions directly in Java code.
+The definition phase in Airline is driven primarily through the use of annotations on classes and their fields.  99% of
+the time you can define your desired CLI entirely through annotations, on the rare occasion where this is not the case
+you can define some portions directly in Java code.
 
 #### Defining the Command
 
-At a minimum we need to annotate our class with the [`@Command`](annotations/command.html) annotation.  This annotation tells Airline about the command, you must at a minimum specify the `name` field giving it the name of the command.  Names should ideally be short and memorable and they **must not** contain whitespace.
+At a minimum we need to annotate our class with the [`@Command`](annotations/command.html) annotation.  This annotation
+tells Airline about the command, you must at a minimum specify the `name` field giving it the name of the command.
+Names should ideally be short and memorable and they **must not** contain whitespace.
 
 Here we've also defined the `description` field which gives a short description of the command.
 
@@ -100,11 +125,13 @@ In our example our class is annotated with `@Command` like so:
 public class GettingStarted {
 ```
 
-There are lots of other things that we can define on our command if we want, please see the [`@Command` Annotation](annotations/command.html) documentation to learn more.
+There are lots of other things that we can define on our command if we want, please see the [`@Command`
+Annotation](annotations/command.html) documentation to learn more.
 
 #### Defining Options
 
-In order to accept options we need to add a field to our class and annotate it with the [`@Option`](annotations/option.html) annotation.  In our example the `flag` field is annotated with `@Option` like so:
+In order to accept options we need to add a field to our class and annotate it with the
+[`@Option`](annotations/option.html) annotation.  In our example the `flag` field is annotated with `@Option` like so:
 
 ```java
 @Option(name = { "-f", "--flag" }, description = "An option that requires no values")
@@ -112,9 +139,11 @@ private boolean flag = false;
 ```
 Here we define a `boolean` option which the user may invoke by passing `-f` or `--flag` at the command line.
 
-There are lots of additional things we can define for our option if we want, please see the [`@Option` Annotation](annotations/option.html) documentation to learn more.
+There are lots of additional things we can define for our option if we want, please see the [`@Option`
+Annotation](annotations/option.html) documentation to learn more.
 
-You can have as many `@Option` definitions as you need provided that none of the definitions have overlapping `name` values.  Each `@Option` definition **MUST** be associated with a specific field.
+You can have as many `@Option` definitions as you need provided that none of the definitions have overlapping `name`
+values.  Each `@Option` definition **MUST** be associated with a specific field.
 
 #### Defining Arguments
 
@@ -125,9 +154,11 @@ We can accept additional arbitrary inputs by annotating a field with the [`@Argu
 private List<String> args;
 ```
 
-This will be populated with a list of arguments received at the command line which were not otherwise interpreted by Airline i.e. anything that was not an option or a command/group name.
+This will be populated with a list of arguments received at the command line which were not otherwise interpreted by
+Airline i.e. anything that was not an option or a command/group name.
 
-There are several additional things we can define for our arguments if we want, please see the [`@Arguments` Annotation](annotations/arguments.html) documentation to learn more.
+There are several additional things we can define for our arguments if we want, please see the [`@Arguments`
+Annotation](annotations/arguments.html) documentation to learn more.
 
 ### Parsing Phase
 
@@ -137,16 +168,21 @@ For a single command like this we can create a parser in a single line like so:
 SingleCommand<GettingStarted> parser = SingleCommand.singleCommand(GettingStarted.class);
 ```
 
-This tells Airline to extract the annotation meta-data from the given class - `GettingStarted` in our example - and to use that to prepare the meta-data necessary to parse user input.  We can then create an instance of our class with the fields appropriately populated based on our option and argument definitions by parsing the command line arguments like so:
+This tells Airline to extract the annotation meta-data from the given class - `GettingStarted` in our example - and to
+use that to prepare the meta-data necessary to parse user input.  We can then create an instance of our class with the
+fields appropriately populated based on our option and argument definitions by parsing the command line arguments like
+so:
 
 ```java
 GettingStarted cmd = parser.parse(args);
 ```
-Here we simply pass the received command line arguments to our previously created parser and Airline creates and populates an instance of our class appropriately.
+Here we simply pass the received command line arguments to our previously created parser and Airline creates and
+populates an instance of our class appropriately.
 
 ### Interrogation Phase
 
-Finally we can now interrogate the options received and act accordingly, in this example this phase has been placed into a separate `run()` method for convenience e.g.
+Finally we can now interrogate the options received and act accordingly, in this example this phase has been placed into
+a separate `run()` method for convenience e.g.
 
 ```java
 private void run() {
@@ -156,11 +192,13 @@ private void run() {
 }
 ```
 
-Since we have an instance of the class we can access the fields as we would do normally since Airline has populated them with the values passed in at the command line.
+Since we have an instance of the class we can access the fields as we would do normally since Airline has populated them
+with the values passed in at the command line.
 
 ## Building a CLI
 
-Now you've seen how to create a simple single command program we can move on to creating a more complex Git style CLI where multiple commands are provided.  Let's take a look at `BasicCli.java`:
+Now you've seen how to create a simple single command program we can move on to creating a more complex Git style CLI
+where multiple commands are provided.  Let's take a look at `BasicCli.java`:
 
 ```java
 @Cli(name = "basic", 
@@ -178,7 +216,8 @@ public class BasicCli {
 
 ### Definition Phase
 
-For a more complex CLI we need to use the [`@Cli`](annotations/cli.html) annotation to specify our CLI.  In our example our `@Cli` annotation looks like the following:
+For a more complex CLI we need to use the [`@Cli`](annotations/cli.html) annotation to specify our CLI.  In our example
+our `@Cli` annotation looks like the following:
 
 ```java
 @Cli(name = "basic", 
@@ -187,9 +226,13 @@ For a more complex CLI we need to use the [`@Cli`](annotations/cli.html) annotat
     commands = { GettingStarted.class, Tool.class })
 ```
 
-This states that our CLI has a `name` of `basic` and that it consists of two commands - `GettingStarted.class` and `Tool.class`.   Each command itself needs to be appropriately defined with at minimum a `@Command` annotation as shown in the earlier `GettingStarted.java` example.
+This states that our CLI has a `name` of `basic` and that it consists of two commands - `GettingStarted.class` and
+`Tool.class`.   Each command itself needs to be appropriately defined with at minimum a `@Command` annotation as shown
+in the earlier `GettingStarted.java` example.
 
-We also specify that `GettingStarted.class` will serve as our `defaultCommand`, this specifies what the behaviour of our CLI is if a user does not explicitly provide the name of the command to be run.  The `commands` field is used to provide an array of all the commands that make up the CLI.
+We also specify that `GettingStarted.class` will serve as our `defaultCommand`, this specifies what the behaviour of our
+CLI is if a user does not explicitly provide the name of the command to be run.  The `commands` field is used to provide
+an array of all the commands that make up the CLI.
 
 You can see the [`@Cli`](annotations/cli.html) documentation for many more advanced options that the annotation supports.
 
@@ -201,12 +244,18 @@ For a CLI we can create a parser in a single line like so:
 Cli<Runnable> cli = new Cli<Runnable>(BasicCli.class);
 ```
 
-This instructs Airline to extract the annotation meta-data from the given class - `BasicCli` in our example - and use it to prepare the necessary meta-data to parse user input.  Since this is a CLI this will also extract all the meta-data for all the `commands` that you specified as part of your CLI annotation.
+This instructs Airline to extract the annotation meta-data from the given class - `BasicCli` in our example - and use it
+to prepare the necessary meta-data to parse user input.  Since this is a CLI this will also extract all the meta-data
+for all the `commands` that you specified as part of your CLI annotation.
 
-The type parameter given (`Runnable` in this example) specifies a common type for all the commands in the CLI and will be the resulting type from parsing.  `Object` can always be used but often it may be useful to have all your commands implement a common interface as in this example so that they have a standard method that your code can then invoke on the parsed command to have the actual command logic run.
+The type parameter given (`Runnable` in this example) specifies a common type for all the commands in the CLI and will
+be the resulting type from parsing.  `Object` can always be used but often it may be useful to have all your commands
+implement a common interface as in this example so that they have a standard method that your code can then invoke on
+the parsed command to have the actual command logic run.
 
-{% include alert.html %}
-Note that since `Cli` is a class and there is also a `@Cli` annotation if both are used in the same class then one will need to use the fully qualified package name to disambiguate.
+{% include alert.html %} 
+Note that since `Cli` is a class and there is also a `@Cli` annotation if both are used in the
+same class then one will need to use the fully qualified package name to disambiguate. 
 {% include end-alert.html %}
 
 Once we have the `Cli` object we can parse a command like so:
@@ -217,18 +266,23 @@ Runnable cmd = cli.parse(args);
 
 ### Interrogation Phase
 
-Finally you can now run the received command and interrogate the received options and act accordingly.  Since we defined our CLI to have all our commands implement `Runnable` then we can simply call the `run()` method:
+Finally you can now run the received command and interrogate the received options and act accordingly.  Since we defined
+our CLI to have all our commands implement `Runnable` then we can simply call the `run()` method:
 
 ```java
 cmd.run();
 ```
 
-As Airline has populated the fields of the parsed command appropriately it will have all the necessary information it needs to run its command logic.
+As Airline has populated the fields of the parsed command appropriately it will have all the necessary information it
+needs to run its command logic.
 
 ## What Next?
 
-You will probably want to read more about the various [annotations](annotations/) that Airline provides in order to learn how to annotate your commands and CLI with more advanced features.
+You will probably want to read more about the various [annotations](annotations/) that Airline provides in order to
+learn how to annotate your commands and CLI with more advanced features.
 
-It is also worth taking a look at the [Airline in Practise](practise/) pages which detail various practicalities of using Airline in the real world.
+It is also worth taking a look at the [Airline in Practise](practise/) pages which detail various practicalities of
+using Airline in the real world.
 
-We'd also recommend learning about the [Help](help/) system which you can use to produce help for your commands and CLIs in a variety of common formats.
+We'd also recommend learning about the [Help](help/) system which you can use to produce help for your commands and CLIs
+in a variety of common formats.

--- a/docs/guide/parser/index.md
+++ b/docs/guide/parser/index.md
@@ -162,9 +162,24 @@ Like other aspects this can be customised where necessary by setting the `comman
 [`@Parser`](../annotations/parser.html) annotation. This might be useful this can be useful if you want to integrate
 your CLI with a dependency injection framework or if your command classes have a more complex constructor.
 
+#### Configurable Composition
+
+{% include req-ver.md version="2.9.0" %}
+
+Since **2.9.0** the annotations used to indicate to Airline that a field is used for composition and its type should
+be further inspected for relevant Airline annotations became fully configurable.  This allows you to use an annotation
+of your choice for composition enabling better integration of Airline CLIs with dependency injection frameworks.
+
+This can be customised via the `compositionAnnotationClasses` field of your [`@Parser`](../annotations/parser.html)
+annotation.  Unlike similar fields of the annotation this takes the classes as `String` class names rather than `Class`
+objects.  This allows Airline to have a default configuration that can dynamically support several different composition
+annotations out of the box without knowing which is actually present at runtime in your application.  See the
+[Composition](../practise/oop.html#composition) documentation for more detail on this.
+
 #### Metadata Introspection
 
-If your command class declares fields with the Java `@Inject` annotation that have Airline metadata types -
-`GlobalMetadata`, `CommandGroupMetadata` and `CommandMetadata` - then your command class instance will also have those
-populated with the relevant parser metadata. This allows commands to introspect the CLI they belong to which can be
-extremely useful for things like help commands.
+If your command class declares fields with the Java `@AirlineModule` annotation (or another [composition
+annotation](../practise/oop.html#configurable-composition)) that have Airline metadata types - `GlobalMetadata`,
+`CommandGroupMetadata` and `CommandMetadata` - then your command class instance will also have those populated with the
+relevant parser metadata. This allows commands to introspect the CLI they belong to which can be extremely useful for
+things like help commands.

--- a/docs/guide/practise/oop.md
+++ b/docs/guide/practise/oop.md
@@ -7,7 +7,11 @@ title: Inheritance and Composition
 
 ## Inheritance
 
-When you define a class as being a [`@Command`](../annotations/command.html) Airline will automatically discover command metadata by examining the class hierarchy of the annotated class.  By this we mean that it will walk up the hierarchy to base classes to discover additional Airline annotations that are inherited by the command class.  This means that you can use standard inheritance to define base classes that contain [`@Option`](../annotations/option.html) definitions that can be inherited by multiple command implementations.
+When you define a class as being a [`@Command`](../annotations/command.html) Airline will automatically discover command
+metadata by examining the class hierarchy of the annotated class.  By this we mean that it will walk up the hierarchy to
+base classes to discover additional Airline annotations that are inherited by the command class.  This means that you
+can use standard inheritance to define base classes that contain [`@Option`](../annotations/option.html) definitions
+that can be inherited by multiple command implementations.
 
 For example we might want to have all our commands have a verbose option available e.g.
 
@@ -37,31 +41,59 @@ public abstract class MaybeVerboseCommand extends BaseCommand {
 }
 ```
 
-Note that we still need to follow normal inheritance best practises about field visibility, in the above example the field in the parent class is marked as `protected` so that we can access in the child class.
+Note that we still need to follow normal inheritance best practises about field visibility, in the above example the
+field in the parent class is marked as `protected` so that we can access in the child class.
 
 ### Option Overriding
 
-When we have larger class hierarchies it may be desirable to override the implementation of a option to be more specific to a given command.  Details on overriding options are given in the documentation of the [`@Option` Overriding](../annotations/option.html#overrides-and-sealed) annotation.
+When we have larger class hierarchies it may be desirable to override the implementation of a option to be more specific
+to a given command.  Details on overriding options are given in the documentation of the [`@Option`
+Overriding](../annotations/option.html#overrides-and-sealed) annotation.
 
-When you override an option Airline will still populate all the relevant fields individually.  So for example if you override an option in a child class both the parent and child field for that option will get populated if the user specifies the option.  This ensures that any logic in the parent and child can use the field values as they would usually.
+When you override an option Airline will still populate all the relevant fields individually.  So for example if you
+override an option in a child class both the parent and child field for that option will get populated if the user
+specifies the option.  This ensures that any logic in the parent and child can use the field values as they would
+usually.
 
 #### Option Restrictions
 
-If you are using [Restrictions](../restrictions/) then any restrictions defined on an option are controlled by the deepest definition of the option with restrictions.  This means that you can change the restrictions on an option by defining new restrictions on an override.  Equally if you don't define any restrictions with an override you automatically inherit any restrictions defined by the parent definition.
+If you are using [Restrictions](../restrictions/) then any restrictions defined on an option are controlled by the
+deepest definition of the option with restrictions.  This means that you can change the restrictions on an option by
+defining new restrictions on an override.  Equally if you don't define any restrictions with an override you
+automatically inherit any restrictions defined by the parent definition.
 
-If you want to remove the restrictions on an overridden option you can use the special [`@Unrestricted`](../annotations/unrestricted.html) annotation to denote this.
+If you want to remove the restrictions on an overridden option you can use the special
+[`@Unrestricted`](../annotations/unrestricted.html) annotation to denote this.
 
 ### Help Section Inheritance
 
-If you are using Help Annotations e.g. [`@Discussion`](../annotations/discussion.html) then any help sections defined are automatically inherited by child classes.  For example you might wish to define a [`@Copyright`](../annotations/copyright.html) annotation on your base class to automatically add a Copyright section to all your commands.
+If you are using Help Annotations e.g. [`@Discussion`](../annotations/discussion.html) then any help sections defined
+are automatically inherited by child classes.  For example you might wish to define a
+[`@Copyright`](../annotations/copyright.html) annotation on your base class to automatically add a Copyright section to
+all your commands.
 
-If the same help annotation is defined multiple times in a class hierarchy the deepest definition is used.  So if your parent defines an `@Copyright` annotation and your child class also defines an `@Copyright` annotation then your child definition will be used.
+If the same help annotation is defined multiple times in a class hierarchy the deepest definition is used.  So if your
+parent defines an `@Copyright` annotation and your child class also defines an `@Copyright` annotation then your child
+definition will be used.
 
-If you wish to hide an inherited help section the special [`@HideSection`](../annotations/hide-section.html) annotation can be used to do this.
+If you wish to hide an inherited help section the special [`@HideSection`](../annotations/hide-section.html) annotation
+can be used to do this.
 
 ## Composition
 
-Additionally we may want to break out sets of related options into reusable modules and compose these together into our classes.  When Airline is scanning the command class for annotated fields it will also scan any field marked with the standard Java `@Inject` annotation.  The class for that field will be scanned and any further annotations included into the command metadata.  For example if we wanted to make our verbose option reusable across commands without any common ancestor we could do the following:
+Additionally we may want to break out sets of related options into reusable modules and compose these together into our
+classes.  When Airline is scanning the command class for annotated fields it will also scan any field marked with the
+[`@AirlineModule`](../annotations/module.html) annotation.  The class for that field will be scanned and any further
+annotations included into the command metadata.
+
+{% include alert.html %}
+The default annotation for this changed to `@AirlineModule` in the **2.9.0**, see 
+[Historical Composition](#historical-composition) for past alternatives.
+{% include end-alert.html %}
+
+
+For example if we wanted to make our verbose option reusable across commands without any common ancestor we could do the
+following:
 
 ```java
 public class VerbosityModule {
@@ -75,13 +107,13 @@ public class VerbosityModule {
 @Command(name = "module-reuse", description = "A command that demonstrates re-use of modules and composition with locally defined options")
 public class ModuleReuse implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private HelpOption<ExampleRunnable> help;
 
     /**
-     * A field marked with {@link Inject} will also be scanned for options
+     * A field marked with {@link AirlineModule} will also be scanned for options
      */
-    @Inject
+    @AirlineModule
     private VerbosityModule verbosity = new VerbosityModule();
 
     @Arguments
@@ -102,4 +134,56 @@ public class ModuleReuse implements ExampleRunnable {
 }
 ```
 
-Note that we are able to compose as many other classes as we want by defining multiple fields annotated with `@Inject`.  Note that when accessing these options we have to access them via their originating fields so again we need to be aware of field visibility when composing modules together.
+Note that we are able to compose as many other classes as we want by defining multiple fields annotated with
+`@AirlineModule`. Note that when accessing these options we have to access them via their originating fields so again we
+need to be aware of field visibility when composing modules together.
+
+### Historical Composition
+
+In versions of Airline prior to **2.9.0** we used the `javax.inject.Inject` annotation to achieve composition, so in the
+above example you would replace `@AirlineModule` with `@Inject` and you may still see this used in old example code or
+projects using older Airline releases.
+
+However multiple users have reported over the years that this conflicts with its usage by dependency injection
+frameworks.  Additionally with the JavaEE `javax.*` packages moving under the control of the Eclipse Foundation and
+being repacked as `jakarta.*` package instead there are now conflicts between different versions of the same annotation.
+Therefore the decision was taken as of **2.9.0** to change the annotation used for this to
+[`@AirlineModule`](../annotations/module.html).
+
+For backwards compatibility the 2.9.x releases continue to support the old `@Inject` annotation so there is no breaking 
+change for existing users upgrading to newer Airline releases.  Currently the following annotations may be used for 
+composition:
+
+- `com.github.rvesse.airline.annotations.AirlineModule`
+- `javax.inject.Inject`
+- `jakarta.inject.Inject`
+- `com.google.inject.Inject`
+
+{% include alert.html %} 
+While the above list represents the currently supported annotations future releases beyond
+2.9.x will only support `@AirlineModule` by default.  Therefore users may wish to migrate to using this new annotation
+sooner rather than later.  2.9.0 onwards does support [Configurable Composition](#configurable-composition) so users 
+will be able to use whichever annotations they see fit for their use cases.
+{% include end-alert.html %}
+
+### Configurable Composition
+
+{% include req-ver.md version="2.9.0" %}
+
+As of **2.9.0** the annotations considered to mark a field as being used for composition, i.e. a field whose value type
+Airline should scan for further Airline annotations, became fully configurable.
+
+You can configured this via the `compositionAnnotationClasses` field of your
+[`@Parser`](../annotations/parser.html#composition-annotations) annotation.  This takes an array of strings indicating
+annotation classes that you want Airline to consider as composition annotations e.g.
+
+```java
+@Parser(compositionAnnotationClasses = {
+  "com.github.rvesse.airline.annotations.AirlineModule",
+  "javax.inject.Inject"
+})
+```
+Would configure the parser to treat both [`@AirlineModule`](../annotations/module.html) and `@Inject` as composition
+annotations.  This field is specified using string class names rather than `Class` objects to enable the backwards
+compatibility described [above](#historical-composition) and to allow us to drop the extra dependencies in the future
+without breaking existing consumers of the library.

--- a/docs/guide/practise/oop.md
+++ b/docs/guide/practise/oop.md
@@ -166,6 +166,12 @@ sooner rather than later.  2.9.0 onwards does support [Configurable Composition]
 will be able to use whichever annotations they see fit for their use cases.
 {% include end-alert.html %}
 
+In order to support this backwards compatibility we continue to have dependencies on both the `jakarta.inject` and
+`javax.inject` modules.  The latter is indirectly depended upon via a temporary `airline-backcompact-javaxinject` to
+make it clear that this is for backwards compatibility only and can be exluded for users who have moved to using the new
+[`@AirlineModule`](../annotations/module.html) annotation. As noted in the above warning these dependencies will become
+`optional` in future releases and eventually be removed as mandatory dependencies.
+
 ### Configurable Composition
 
 {% include req-ver.md version="2.9.0" %}
@@ -183,7 +189,11 @@ annotation classes that you want Airline to consider as composition annotations 
   "javax.inject.Inject"
 })
 ```
+
 Would configure the parser to treat both [`@AirlineModule`](../annotations/module.html) and `@Inject` as composition
 annotations.  This field is specified using string class names rather than `Class` objects to enable the backwards
 compatibility described [above](#historical-composition) and to allow us to drop the extra dependencies in the future
 without breaking existing consumers of the library.
+
+If you choose to use additional annotations you may need to explicitly declare additional Maven dependencies to ensure
+those annotation classes are available at runtime.

--- a/docs/guide/practise/workshop.md
+++ b/docs/guide/practise/workshop.md
@@ -3,9 +3,12 @@ layout: slideshow
 title: Workshop - Building a Killer Command Line App with Airline
 ---
 
-This workshop session is designed to give you a complete introduction to the core features of Airline for creating powerful CLIs.  This was originally written for the [Tech Exeter Conference](https://techexeter.uk) series and presented in September 2018.
+This workshop session is designed to give you a complete introduction to the core features of Airline for creating
+powerful CLIs.  This was originally written for the [Tech Exeter Conference](https://techexeter.uk) series and presented
+in September 2018.
 
-The workshop is provided as a HTML slideshow embedded below, use the arrow keys to navigate through the slides.  You can view this in fullscreen by hitting the icon in the top left of the slides.
+The workshop is provided as a HTML slideshow embedded below, use the arrow keys to navigate through the slides.  You can
+view this in fullscreen by hitting the icon in the top left of the slides.
 
 ---
 
@@ -24,9 +27,13 @@ The workshop is provided as a HTML slideshow embedded below, use the arrow keys 
 
 ## Introduction
 
-Everyone builds command line applications at some point but often they are cobbled together or full of needless boiler plate. Airline takes a fully declarative approach to command line applications allowing users to create powerful and flexible command lines.
+Everyone builds command line applications at some point but often they are cobbled together or full of needless boiler
+plate. Airline takes a fully declarative approach to command line applications allowing users to create powerful and
+flexible command lines.
 
-Airline takes care of lots of heavy lifting providing many features not found in similar libraries including annotation driven value validation [restrictions](../restrictions/index.html), generating [Man pages](../help/man.html) and [Bash completion scripts](../help/bash.html) to name just a few.
+Airline takes care of lots of heavy lifting providing many features not found in similar libraries including annotation
+driven value validation [restrictions](../restrictions/index.html), generating [Man pages](../help/man.html) and [Bash
+completion scripts](../help/bash.html) to name just a few.
 
 In the workshop session we'll work through an example command line application to see just how powerful this can be.
 
@@ -35,7 +42,8 @@ In the workshop session we'll work through an example command line application t
 * Software Engineer at Cray in the AI & Analytics Group
 * Long background in open source
     * Have been releasing open source software since around 2003
-    * Involved at the [Apache Software Foundation](https://www.apache.org) (ASF) since 2012 and was elected as a  member in 2015
+    * Involved at the [Apache Software Foundation](https://www.apache.org) (ASF) since 2012 and was elected as a 
+      member in 2015
     * [https://github.com/rvesse]()
 
 {% include slide-end.md %}
@@ -64,7 +72,8 @@ You can find these slides at [{{ site.url }}{{ site.baseurl }}/guide/practise/wo
 - Airline started out as an open source project on GitHub back in January 2012.
 - I first encountered this library in use in one of our competitors products partway through that year.  
 - I quickly started using it in my own work but encountered a few limitations.
-- The original authors were not receptive to pull requests so I forked the code and started maintaining my own version that has since evolved considerably.
+- The original authors were not receptive to pull requests so I forked the code and started maintaining my own version 
+  that has since evolved considerably.
 - First release of my fork was December 2014
 - Latest release at time of writing was 2.6.0
 - Have built various personal and work projects with it e.g.
@@ -93,13 +102,15 @@ It also enables us to do optional build time checking of our definitions to ensu
 
 Secondly we look to avoid the typical boiler plate code associated with many command line libraries.
 
-You **shouldn't** need to write a ton of `if` statements to check that values for options fall in specified ranges or meet common application constraints.
+You **shouldn't** need to write a ton of `if` statements to check that values for options fall in specified ranges or
+meet common application constraints.
 
 #### Allow deep customisation
 
 Finally we don't want to tie you into a particular implementation approach.
 
-We provide extensibility of almost every aspect of the parsing process yet provide a general purpose default setup that should suit many users.
+We provide extensibility of almost every aspect of the parsing process yet provide a general purpose default setup that
+should suit many users.
 
 So a basic CLI should just work, advanced CLIs can be configured as desired
 
@@ -108,18 +119,23 @@ So a basic CLI should just work, advanced CLIs can be configured as desired
 
 ## Workshop Overview
 
-Due to time constraints this will be more of an interactive demo, almost everything in these slides is in the GitHub repo so you can play along.
+Due to time constraints this will be more of an interactive demo, almost everything in these slides is in the GitHub
+repo so you can play along.
 
-For this workshop we are going to build an example command line application called `send-it` for shipping of packages.  The example code in these slides is typically truncated to omit things like import declarations for brevity, the full code is linked alongside each example.
+For this workshop we are going to build an example command line application called `send-it` for shipping of packages.
+The example code in these slides is typically truncated to omit things like import declarations for brevity, the full
+code is linked alongside each example.
 
-The example code all lives inside the Airline git repository at [https://github.com/rvesse/airline/tree/master/airline-examples](https://github.com/rvesse/airline/tree/master/airline-examples)
+The example code all lives inside the Airline git repository at
+[https://github.com/rvesse/airline/tree/master/airline-examples](https://github.com/rvesse/airline/tree/master/airline-examples)
 
 {% include slide-end.md %}
 {% include slide-start.md %}
 
 ### Following Along with the Examples
 
-We use `>` to indicate that a command should be run at a command prompt and `<input>` within that to indicate some input is needed.
+We use `>` to indicate that a command should be run at a command prompt and `<input>` within that to indicate some input
+is needed.
 
 To follow along you should start by checking out the code and building the examples:
 
@@ -154,28 +170,35 @@ Or for Windows Users:
 
 ## Step 1 - Define Options
 
-Airline works with POJOs (Plain Old Java Objects) so firstly we need to define some classes that are going to hold our commands options.
+Airline works with POJOs (Plain Old Java Objects) so firstly we need to define some classes that are going to hold our
+commands options.
 
-We can define our options across multiple classes and our inheritance hierarchy i.e. you can create a `BaseCommand` with your common options.
+We can define our options across multiple classes and our inheritance hierarchy i.e. you can create a `BaseCommand` with
+your common options.
 
 Or you can define options in standalone classes and compose them together.
 
-We're going to see the latter approach in this workshop, see [Inheritance and Composition](oop.html) for more detail on the former approach.
+We're going to see the latter approach in this workshop, see [Inheritance and Composition](oop.html) for more detail on
+the former approach.
 
 {% include slide-end.md %}
 {% include slide-start.md %}
 
 ### `@Option`
 
-The [`@Option`](../annotations/option.html) annotation is used to mark a field as being populated by an option.  At a minimum it needs to define the `name` field to provide one/more names that your users will enter to refer to your option e.g.
+The [`@Option`](../annotations/option.html) annotation is used to mark a field as being populated by an option.  At a
+minimum it needs to define the `name` field to provide one/more names that your users will enter to refer to your option
+e.g.
 
 ```java
 @Option(name = { "-e", "--example" })
 private String example;
 ```
-Here we define a simple `String` field and annotate it with `@Option` providing two possible names - `-e` and `--example` - by which users can refer to it.
+Here we define a simple `String` field and annotate it with `@Option` providing two possible names - `-e` and
+`--example` - by which users can refer to it.
 
-Other commonly used fields in the `@Option` annotation include `title` used to specify the title by which the value is referred to in help and `description` used to provide descriptive help information for the option.
+Other commonly used fields in the `@Option` annotation include `title` used to specify the title by which the value is
+referred to in help and `description` used to provide descriptive help information for the option.
 
 {% include slide-end.md %}
 {% include slide-start.md %}
@@ -192,7 +215,8 @@ public class PostalAddress {
     @Required
     public String recipient;
 ```
-So we start with a fairly simply definition, this defines a `--recipient` option and states that it is a required option via the [`@Required`](../annoations/required.html) annotation.
+So we start with a fairly simply definition, this defines a `--recipient` option and states that it is a required option
+via the [`@Required`](../annoations/required.html) annotation.
 
 {% include slide-end.md %}
 {% include slide-start.md %}
@@ -212,16 +236,22 @@ So we start with a fairly simply definition, this defines a `--recipient` option
     @NotBlank
     public String houseName;
 ```
-Now we're starting to get more advanced, here we have two closely related options - `--number` and `--name` - which we declare that we require only one of via the [`@RequireOnlyOne`](../annotations/require-only-one.html) i.e. we've told Airline that one, and only one, of these two options may be specified.
+Now we're starting to get more advanced, here we have two closely related options - `--number` and `--name` - which we
+declare that we require only one of via the [`@RequireOnlyOne`](../annotations/require-only-one.html) i.e. we've told
+Airline that one, and only one, of these two options may be specified.
 
-Additionally for the `--number` option we state that it must be greater than zero via the [`@IntegerRange`](../annotations/integer-range.html) annotation and for the `--name` option we state that it must be [`@NotBlank`](../annotations/not-blank.html) i.e. it must have a non-empty value that is not all whitespace.
+Additionally for the `--number` option we state that it must be greater than zero via the
+[`@IntegerRange`](../annotations/integer-range.html) annotation and for the `--name` option we state that it must be
+[`@NotBlank`](../annotations/not-blank.html) i.e. it must have a non-empty value that is not all whitespace.
 
 {% include slide-end.md %}
 {% include slide-start.md %}
 
 #### Defining a Repeated Option
 
-Here we have an option that may be specified multiple times to provide multiple address lines.  **Importantly** we need to define it with an appropriate `Collection` based type, in this case `List<String>` in order to collect all the address lines specified.
+Here we have an option that may be specified multiple times to provide multiple address lines.  **Importantly** we need
+to define it with an appropriate `Collection` based type, in this case `List<String>` in order to collect all the
+address lines specified.
 
 ```java
     @Option(name = { "-a", "--address", "--line" }, title = "AddressLine", 
@@ -231,7 +261,8 @@ Here we have an option that may be specified multiple times to provide multiple 
     public List<String> addressLines = new ArrayList<>();
 ```
 
-Here we also use the [`@MinOccurences`](../annotations/min-occurrences.html) annotation to state that it must occur at least once in addition to using the previously seen `@Required`
+Here we also use the [`@MinOccurences`](../annotations/min-occurrences.html) annotation to state that it must occur at
+least once in addition to using the previously seen `@Required`
 
 {% include slide-end.md %}
 {% include slide-start.md %}
@@ -247,14 +278,16 @@ Here we also use the [`@MinOccurences`](../annotations/min-occurrences.html) ann
                     flags = java.util.regex.Pattern.CASE_INSENSITIVE)
     public String postCode;
 ```
-Here is another example of a complex restriction, this time we use the [`@Pattern`](../annotations/pattern.html) annotation to enforce a regular expression to validate our postcodes meet the UK format.
+Here is another example of a complex restriction, this time we use the [`@Pattern`](../annotations/pattern.html)
+annotation to enforce a regular expression to validate our postcodes meet the UK format.
 
 {% include slide-end.md %}
 {% include slide-start.md %}
 
 #### Plus Regular Code...
 
-And finally we have some regular Java code in our class.  Your normal logic can co-exist happily alongside your Airline annotations, we'll see this used later to implement our actual command logic.
+And finally we have some regular Java code in our class.  Your normal logic can co-exist happily alongside your Airline
+annotations, we'll see this used later to implement our actual command logic.
 
 ```java
     @Override
@@ -286,7 +319,10 @@ And finally we have some regular Java code in our class.  Your normal logic can 
 
 ### `@Arguments`
 
-The [`@Arguments`](../annotation/arguments.html) annotation is used to annotate a field that will receive arbitrary inputs i.e. anything that is not recognised as an option as defined by your `@Option` annotations.  This is useful when your command wants to operate on a list of things so is typically used in conjunction with a `Collection` typed field e.g. `List<String>`.
+The [`@Arguments`](../annotation/arguments.html) annotation is used to annotate a field that will receive arbitrary
+inputs i.e. anything that is not recognised as an option as defined by your `@Option` annotations.  This is useful when
+your command wants to operate on a list of things so is typically used in conjunction with a `Collection` typed field
+e.g. `List<String>`.
 
 #### `@Arguments` in use
 
@@ -314,13 +350,17 @@ RG19 6HS is a valid postcode
 
 ### Restrictions
 
-So we've already seen a number of [Restrictions](../restrictions/index.html) in the above examples.  This is one of the main ways Airline reduces boiler plate and prefers declarative definitions.  There are lots more built-in restrictions than just those seen so far and you can define [Custom Restrictions](../restrictions/custom.html) if you want to encapsulate reusable restriction logic.
+So we've already seen a number of [Restrictions](../restrictions/index.html) in the above examples.  This is one of the
+main ways Airline reduces boiler plate and prefers declarative definitions.  There are lots more built-in restrictions
+than just those seen so far and you can define [Custom Restrictions](../restrictions/custom.html) if you want to
+encapsulate reusable restriction logic.
 
 Some useful common restrictions include:
 
 - [`@Required`](../annotations/required.html) - For required options/arguments
 - [`@NotBlank`](../annotations/not-blank.html) - To enforce non-blank string values
-- [`@AllowedRawValues`](../annotations/allowed-raw-values.html)/[`@AllowedValues`](../annotations/allowed-values.html) - To restrict options/arguments to a set of acceptable values
+- [`@AllowedRawValues`](../annotations/allowed-raw-values.html)/[`@AllowedValues`](../annotations/allowed-values.html) - 
+  To restrict options/arguments to a set of acceptable values
 - [`@Path`](../annotations/path.html) - Provides restrictions on options/arguments used to refer to files and directories
 
 {% include slide-end.md %}
@@ -334,10 +374,10 @@ So now we've seen the basics of defining options and arguments lets use these to
 @Command(name = "send", description = "Sends a package")
 public class Send implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private PostalAddress address = new PostalAddress();
     
-    @Inject
+    @AirlineModule
     private Package item = new Package();
 
     @Option(name = { "-s",
@@ -390,33 +430,42 @@ The [`@Command`](../annotations/command.html) annotation is used on Java classes
 @Command(name = "send", description = "Sends a package")
 public class Send implements ExampleRunnable {
 ```
-The `@Command` annotation is fairly simple, we simply have a `name` for our command and a `description`.  The `name` is the name users will use to invoke the command, this name can be any string of non-whitespace characters and is the only required field of the `@Command` annotation.
+The `@Command` annotation is fairly simple, we simply have a `name` for our command and a `description`.  The `name` is
+the name users will use to invoke the command, this name can be any string of non-whitespace characters and is the only
+required field of the `@Command` annotation.
 
-The `description` field provides descriptive text about the command that will be used in help output, we'll see this used later.
+The `description` field provides descriptive text about the command that will be used in help output, we'll see this
+used later.
 
 {% include slide-end.md %}
 {% include slide-start.md %}
 
-### Using `@Inject` for composition
+### Using `@AirlineModule` for composition
 
-Often for command line applications you want to define reusable sets of closely related options as we already saw with the `PostalAddress` class.  Airline provides a composition mechanism that makes this easy to do.
+Often for command line applications you want to define reusable sets of closely related options as we already saw with
+the `PostalAddress` class.  Airline provides a composition mechanism that makes this easy to do.
 
 ```java
-    @Inject
+    @AirlineModule
     private PostalAddress address = new PostalAddress();
     
-    @Inject
+    @AirlineModule
     private Package item = new Package();
 ```
 
-Here we compose the previously seen `PostalAddress` class into our command, we use the standard Java `@Inject` annotation to indicate to Airline that it should find options declared by that class.  We also have another set of options defined in a separate class, this time the {% include github-ref.md package="examples.sendit" class="Package" module="airline-examples" %} class is used to provide options relating to the package being sent.
+Here we compose the previously seen `PostalAddress` class into our command, we use the
+[`@AirlineModule`](../annotations/module.html) annotation to indicate to Airline that it should find options declared by
+that class.  We also have another set of options defined in a separate class, this time the {% include github-ref.md
+package="examples.sendit" class="Package" module="airline-examples" %} class is used to provide options relating to the
+package being sent.
 
 {% include slide-end.md %}
 {% include slide-start.md %}
 
 ### Command specific options
 
-As well as composing options defined in other classes we can also define options specific to a command directly in our command class:
+As well as composing options defined in other classes we can also define options specific to a command directly in our
+command class:
 
 ```java
     @Option(name = { "-s",
@@ -424,7 +473,9 @@ As well as composing options defined in other classes we can also define options
     private PostalService service = PostalService.FirstClass;
 ```
  
-Here the command declares an additional option `-s/--service` that is specific to this command.  Here the field actual has an enum type - {% include github-ref.md package="examples.sendit" class="PostalService" module="airline-examples" %} - which Airline happily copes with.
+Here the command declares an additional option `-s/--service` that is specific to this command.  Here the field actual
+has an enum type ({% include github-ref.md package="examples.sendit" class="PostalService" module="airline-examples" %})
+which Airline happily copes with.
 
 For more details on how Airline supports differently typed fields see the [Supported Types](types.html) documentation.
 
@@ -450,14 +501,17 @@ For more details on how Airline supports differently typed fields see the [Suppo
 }
 ```
 
-Finally we have the actual business logic of our class.  In this example application it simply prints out some information but this serves to show that we can access the fields that have been populated by the users command line inputs.
+Finally we have the actual business logic of our class.  In this example application it simply prints out some
+information but this serves to show that we can access the fields that have been populated by the users command line
+inputs.
 
 {% include slide-end.md %}
 {% include slide-start.md %}
 
 ### Invoking our command
 
-In order to actually invoke our command we need to get a parser from Airline and invoke it on the user input.  In this example we do this in our `main(String[] args)` method:
+In order to actually invoke our command we need to get a parser from Airline and invoke it on the user input.  In this
+example we do this in our `main(String[] args)` method:
 
 ```java
     public static void main(String[] args) {
@@ -474,7 +528,9 @@ We can then invoke the `parse()` method passing in our users inputs.
 ```java
             System.exit(cmd.run());
 ```
-Assuming the parsing is successful we now have an instance of our `Send` class which we can invoke methods on like any other Java object.   In this example our business logic is in the `run()` method so we simply call that method and use its return value as the exit code.
+Assuming the parsing is successful we now have an instance of our `Send` class which we can invoke methods on like any
+other Java object.   In this example our business logic is in the `run()` method so we simply call that method and use
+its return value as the exit code.
 
 ```java
         } catch (ParseException e) {
@@ -517,7 +573,9 @@ Airline allows multiple commands to be composed together into a CLI to support c
 
 ### `@Cli`
 
-We use the [`@Cli`](../annotations/cli.html) annotation to define a CLI, this is applied to classes similar to `@Command` e.g. the {% include github-ref.md module="airline-examples" package="examples.sendit" class="SendItCli" %} class:
+We use the [`@Cli`](../annotations/cli.html) annotation to define a CLI, this is applied to classes similar to
+`@Command` e.g. the {% include github-ref.md module="airline-examples" package="examples.sendit" class="SendItCli" %}
+class:
 
 ```java
 @Cli(name = "send-it", 
@@ -555,7 +613,8 @@ As we saw with `@Command` this is pretty self-explanatory:
 @Cli(name = "send-it", 
      description = "A demonstration CLI around shipping",
 ```
-The `name` is the name that you expect users to type at the command line, typically you'll create a Shell script named this which invokes your actual Java application.
+The `name` is the name that you expect users to type at the command line, typically you'll create a Shell script named
+this which invokes your actual Java application.
 
 As seen previously `description` is used to provide descriptive text that will get included in help output.
 
@@ -576,13 +635,17 @@ commands = {
 defaultCommand = Help.class, 
 ```
 
-The `commands` field of the annotation defines the classes that provide your commands.  Each of these must be appropriately annotated with `@Command`.
+The `commands` field of the annotation defines the classes that provide your commands.  Each of these must be
+appropriately annotated with `@Command`.
 
-We also see the `defaultCommand` field used to indicate what command is invoked if the user doesn't invoke a command.  This can be useful to provide default behaviour and is often used to point to the help system.
+We also see the `defaultCommand` field used to indicate what command is invoked if the user doesn't invoke a command.
+This can be useful to provide default behaviour and is often used to point to the help system.
 
 ---
 
-**NB** - Generally it is useful for all your commands to have a common parent class or interface since as we'll see in a few slides time we'll need to declare a type when creating a parser.  In this case all our commands implement {% include github-ref.md package="examples" module="airline-examples" class="ExampleRunnable" %}
+**NB** - Generally it is useful for all your commands to have a common parent class or interface since as we'll see in a
+few slides time we'll need to declare a type when creating a parser.  In this case all our commands implement {% include
+github-ref.md package="examples" module="airline-examples" class="ExampleRunnable" %}
 
 {% include slide-end.md %}
 {% include slide-start.md %}
@@ -599,14 +662,17 @@ parserConfiguration = @Parser(
        errorHandler = CollectAll.class
      )
 ```
-The one important thing to point out here is we are changing the `errorHandler` to `CollectAll` which will allow us to more intelligently handle errors later.
+The one important thing to point out here is we are changing the `errorHandler` to `CollectAll` which will allow us to
+more intelligently handle errors later.
 
 {% include slide-end.md %}
 {% include slide-start.md %}
 
 ### Invoking our CLI
 
-So you probably noticed we had zero logic in the class defining our CLI, similar to our single command example we need to define an appropriate `main()` method for our CLI.  This we do in the {% include github-ref.md package="examples.sendit" module="airline-examples" class="SendIt" %} class:
+So you probably noticed we had zero logic in the class defining our CLI, similar to our single command example we need
+to define an appropriate `main()` method for our CLI.  This we do in the {% include github-ref.md
+package="examples.sendit" module="airline-examples" class="SendIt" %} class:
 
 ```java
 public class SendIt {
@@ -666,23 +732,27 @@ As mentioned we need to define a type for the commands that will be parsed.  So 
 // Parse with a result to allow us to inspect the results of parsing
 ParseResult<ExampleRunnable> result = parser.parseWithResult(args);
 ```
-Here we call the `parseWithResult()` method passing in the user arguments received by our `main()` method.  This will give us a `ParseResult` instance that we can inspect to see if parsing succeeded:
+Here we call the `parseWithResult()` method passing in the user arguments received by our `main()` method.  This will
+give us a `ParseResult` instance that we can inspect to see if parsing succeeded:
 
 ```java
 if (result.wasSuccessful()) {
     // Parsed successfully, so just run the command and exit
     System.exit(result.getCommand().run());
 ```
-Assuming successful parsing we can simply call `getCommand()` on our `result` and then invoke its `run()` method since all our commands implement a common interface.
+Assuming successful parsing we can simply call `getCommand()` on our `result` and then invoke its `run()` method since
+all our commands implement a common interface.
 
-Alternatively we could have just called `parse(args)` which would return either the parsed command, throw an exception or return `null` depending on the user inputs and the parser configuration.
+Alternatively we could have just called `parse(args)` which would return either the parsed command, throw an exception
+or return `null` depending on the user inputs and the parser configuration.
 
 {% include slide-end.md %}
 {% include slide-start.md %}
 
 #### Handling Errors
 
-If parsing wasn't successful then we need to do something about that.  We specified a different error handler earlier that allows us to collect up all the errors:
+If parsing wasn't successful then we need to do something about that.  We specified a different error handler earlier
+that allows us to collect up all the errors:
 
 ```java
 } else {
@@ -711,7 +781,8 @@ Followed by invoking the help system to display the help for the CLI.
 
 ### Shell Script
 
-As noted earlier we usually want to create an entry point shell script for our CLI that matches the name declared in our `@Cli` annotation.
+As noted earlier we usually want to create an entry point shell script for our CLI that matches the name declared in our
+`@Cli` annotation.
 
 Here's the contents of [`send-it`]({{ site.github.repo }}/blob/master/airline-examples/send-it):
 
@@ -768,7 +839,8 @@ Why not try asking for help on the `send` command we saw earlier:
 
 So how did that last demo work?
 
-Airline includes a help system that can generate help in a variety of formats plus prebuilt commands and options that can be added into your commands/CLIs.
+Airline includes a help system that can generate help in a variety of formats plus prebuilt commands and options that
+can be added into your commands/CLIs.
 
 We can invoke help in a number of ways:
 
@@ -783,12 +855,13 @@ Let's see the difference between each.
 
 ### Adding `HelpOption` to our commands
 
-This is a pre-built class which defines a `-h`/`--help` option, therefore we can compose this using `@Inject` as seen earlier:
+This is a pre-built class which defines a `-h`/`--help` option, therefore we can compose this using
+[`@AirlineModule`](../annotations/module.html) as seen earlier:
 
 ```java
 @Command(name = "simple", description = "A simple example command")
 public class Simple implements ExampleRunnable {
-    @Inject
+    @AirlineModule
     private HelpOption<Simple> help;
     
     // Rest of implementation omitted for brevity
@@ -809,7 +882,9 @@ public class Simple implements ExampleRunnable {
 }
 ```
 
-We can see in the `run()` method we call the `showHelpIfRequested()` method to check if the user requested help.  If this returns `true` then help was requested and has been shown so we just exit.  If this returns `false` then we continue with our normal logic.
+We can see in the `run()` method we call the `showHelpIfRequested()` method to check if the user requested help.  If
+this returns `true` then help was requested and has been shown so we just exit.  If this returns `false` then we
+continue with our normal logic.
 
 Let's try that:
 
@@ -881,7 +956,7 @@ Even if you can't incorporate the `Help` command directly you can call its stati
                      description = "A command that provides help on other commands")
 public class Help implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private GlobalMetadata<ExampleRunnable> global;
 
     @Arguments(description = "Provides the name of the commands you want to provide help for")
@@ -951,7 +1026,8 @@ This is everything you need to make a functional CLI with Airline.
 
 ### So What's Next?
 
-The user guide which has been linked throughout these slides covers all these topics, plus many more, in lots more detail and examples.  Find it at [http://rvesse.github.io/airline/]()
+The user guide which has been linked throughout these slides covers all these topics, plus many more, in lots more
+detail and examples.  Find it at [http://rvesse.github.io/airline/]()
 
 Please try it out, post questions, problems etc. at [http://github.com/rvesse/airline/issues]()
 
@@ -961,29 +1037,35 @@ Please feel free to ask questions now!
 
 #### Time Allowing...
 
-The remainder of the slides give a quick tour of some of the more advanced features of the library.  If we have any extra time left we'll take a look at these...
+The remainder of the slides give a quick tour of some of the more advanced features of the library.  If we have any
+extra time left we'll take a look at these...
 
 {% include slide-end.md %}
 {% include slide-start.md %}
 
 ## Customising the Parser
 
-As we glossed over earlier we can optionally customise our parser to change the command line behaviour in a variety of ways.
+As we glossed over earlier we can optionally customise our parser to change the command line behaviour in a variety of
+ways.
 
-So we saw earlier in our `SendItCli` example the parser being customised via the `parserConfiguration` field of the `@Cli` annotation.  Let's look more into that now.
+So we saw earlier in our `SendItCli` example the parser being customised via the `parserConfiguration` field of the
+`@Cli` annotation.  Let's look more into that now.
 
 ### `@Parser`
 
 The [`@Parser`](../annotations/parser.html) annotation can be used in two ways:
 
-- Applied directly to a class annotated with [`@Command`](../annotations/command.html), this customises the parser for `SingleCommand` based parsers
-- Used in the `parserConfiguration` field of the [`@Cli`](../annotations/cli.html) annotation, this customises the parser for `Cli` based parsers
+- Applied directly to a class annotated with [`@Command`](../annotations/command.html), this customises the parser for
+  `SingleCommand` based parsers
+- Used in the `parserConfiguration` field of the [`@Cli`](../annotations/cli.html) annotation, this customises the
+  parser for `Cli` based parsers
 
 There are lots of behaviours that can be customised with this annotation e.g.
 
 - Providing [User Defined Aliases](aliases.html) so users can define command aliases within your CLIs
 - Configuring option styles (see next slide for discussion of this)
-- Automated abbreviation support i.e. allow users to type only partial command/option names provided what they enter is unambiguous
+- Automated abbreviation support i.e. allow users to type only partial command/option names provided what they enter is
+  unambiguous
 - Error Handling (as seen earlier)
 
 {% include slide-end.md %}
@@ -993,9 +1075,12 @@ There are lots of behaviours that can be customised with this annotation e.g.
 
 By default Airline parses three common option styles in the following order of preference:
 
-- {% include javadoc-ref.md class="StandardOptionParser" package="parser.options" %} - Simple white space separated option and values e.g. `--name value` sets the option `--name` to `value`
-- {% include javadoc-ref.md class="LongGetOptParser" package="parser.options" %} - Long form GNU `getopt` style e.g. `--name=value` sets the option `--name` to `value`
-- {% include javadoc-ref.md class="ClassicGetOptParser" package="parser.options" %} - Short form GNU `getopt` style e.g. `-n1` sets the option `-n` to `1`
+- {% include javadoc-ref.md class="StandardOptionParser" package="parser.options" %} - Simple white space separated
+  option and values e.g. `--name value` sets the option `--name` to `value`
+- {% include javadoc-ref.md class="LongGetOptParser" package="parser.options" %} - Long form GNU `getopt` style e.g.
+  `--name=value` sets the option `--name` to `value`
+- {% include javadoc-ref.md class="ClassicGetOptParser" package="parser.options" %} - Short form GNU `getopt` style e.g.
+  `-n1` sets the option `-n` to `1`
 
 This can be customised via several fields of the [`@Parser`](../annotations/parser.html) annotation e.g.
 
@@ -1012,8 +1097,12 @@ parserConfiguration = @Parser(
 
 A couple of additional styles are built-in but not enabled by default:
 
-- {% include javadoc-ref.md class="MaybePairValueOptionParser" package="parser.options" %} - Arity 2 options where the user may specify the values as whitespace/`=` separated e.g. `--name foo bar` and `--name foo=bar` are both acceptable and set the option `--name` to the values `foo` and `bar`
-- {% include javadoc-ref.md class="ListValueOptionParser" package="parser.options" %} - Options that may be specified multiple times can be specified in a compact comma separated list form e.g. `--name foo,bar` sets the option `--name` to the values `foo` and `bar`.
+- {% include javadoc-ref.md class="MaybePairValueOptionParser" package="parser.options" %} - Arity 2 options where the
+  user may specify the values as whitespace/`=` separated e.g. `--name foo bar` and `--name foo=bar` are both acceptable
+  and set the option `--name` to the values `foo` and `bar`
+- {% include javadoc-ref.md class="ListValueOptionParser" package="parser.options" %} - Options that may be specified
+  multiple times can be specified in a compact comma separated list form e.g. `--name foo,bar` sets the option `--name`
+  to the values `foo` and `bar`.
 
 **NB** - Power Users can also create [Custom Option Parsers](../parser/options.html) if desired.
 
@@ -1022,9 +1111,11 @@ A couple of additional styles are built-in but not enabled by default:
 
 ### Allowing complex numeric inputs
 
-Airline allows for customising how it interprets numeric values passed to any `@Option`/`@Arguments` annotated field that has a numeric type i.e. `byte`, `short`, `int`, `long`, `float` and `double` or their boxed equivalents.
+Airline allows for customising how it interprets numeric values passed to any `@Option`/`@Arguments` annotated field
+that has a numeric type i.e. `byte`, `short`, `int`, `long`, `float` and `double` or their boxed equivalents.
 
-This can be controlled either globally on the `@Parser` annotation with the `numericTypeConverter` field or on a per-option basis by using the `typeConverterProvider` e.g.
+This can be controlled either globally on the `@Parser` annotation with the `numericTypeConverter` field or on a
+per-option basis by using the `typeConverterProvider` e.g.
 
 ```java
 @Parser(numericTypeConverter=Hexadecimal.class)
@@ -1058,17 +1149,21 @@ Exiting with Code 0
 
 ## Generating Manual Pages
 
-Manual pages are provided by using help generator as seen earlier.  This is provided in the separate [`airline-help-man`](../help/man.html) module.
+Manual pages are provided by using help generator as seen earlier.  This is provided in the separate
+[`airline-help-man`](../help/man.html) module.
 
-If we use {% include javadoc-ref.md class="ManCommandUsageGenerator" package="help.man" module="airline-help-man" %} or {% include javadoc-ref.md class="ManGlobalUsageGenerator" package="help.man" module="airline-help-man" %} our output will be Troff plus `man` extensions that can be rendered by the `man` command.
+If we use {% include javadoc-ref.md class="ManCommandUsageGenerator" package="help.man" module="airline-help-man" %} or
+{% include javadoc-ref.md class="ManGlobalUsageGenerator" package="help.man" module="airline-help-man" %} our output
+will be Troff plus `man` extensions that can be rendered by the `man` command.
 
-For example the {% include github-ref.md class="Manuals" package="examples.cli.commands" module="airline-examples" %} class demonstrates this:
+For example the {% include github-ref.md class="Manuals" package="examples.cli.commands" module="airline-examples" %}
+class demonstrates this:
 
 ```java
 @Command(name = "generate-manuals", description = "Generates manual pages for this CLI that can be rendered with the man tool")
 public class Manuals implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private GlobalMetadata<ExampleRunnable> global;
 
     @Option(name = "--include-hidden", description = "When set hidden commands and options are shown in help", hidden = true)
@@ -1100,7 +1195,8 @@ Generated manuals to send-it.1
 
 ## Providing Bash Completion
 
-By the same mechanism we can also do [Bash completion](../help/bash.html), we may need to use the additional `@BashCompletion` annotation on our option/argument fields to control how we'd like Bash to complete things.
+By the same mechanism we can also do [Bash completion](../help/bash.html), we may need to use the additional
+`@BashCompletion` annotation on our option/argument fields to control how we'd like Bash to complete things.
 
 We can then create a command like {% include github-ref.md class="BashCompletions" package="examples.cli.commands" %}:
 
@@ -1108,7 +1204,7 @@ We can then create a command like {% include github-ref.md class="BashCompletion
 @Command(name = "generate-completions", description = "Generates a Bash completion script, the file can then be sourced to provide completion for this CLI")
 public class BashCompletion implements ExampleRunnable {
 
-    @Inject
+    @AirlineModule
     private GlobalMetadata<ExampleRunnable> global;
     
     @Option(name = "--include-hidden", description = "When set hidden commands and options are shown in help", hidden = true)

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,14 +9,16 @@ permalink: index.html
 Airline is an annotation-driven Java library for building Command Line Interfaces (CLIs), it supports simple commands
 all the way through to complex Git style CLIs with groups and user defined command aliases.
 
-Airline aims to reduce the boiler plate code typically associated with CLIs in Java, many common behaviours can be achieved purely with annotations and zero user code.  Let's take a look at an ultra simple example:
+Airline aims to reduce the boiler plate code typically associated with CLIs in Java, many common behaviours can be
+achieved purely with annotations and zero user code.  Let's take a look at an ultra simple example:
 
 {% include code/getting-started.md %}
 
 This is explained in depth in the [Introduction to Airline](guide/) but essentially we had to do the following:
 
 - Annotate our class with [`@Command`](annotations/command.html) to indicate that it is a command
-- Annotate fields with [`@Option`](annotations/option.html) and [`@Arguments`](annotations/arguments.html) to indicate that they receive values from the command line
+- Annotate fields with [`@Option`](annotations/option.html) and [`@Arguments`](annotations/arguments.html) to indicate
+  that they receive values from the command line
 - Use `SingleCommand.singleCommand()` to create a parser from our class
 - Call `parse()` to pass the command line arguments
 - Implement our command logic as desired, here it is contained in the `run()` method
@@ -38,6 +40,16 @@ You can get Airline from Maven central by specifying the following Maven coordin
 ```
 
 Where `X.Y.Z` is your desired version, the current stable release is `{{ site.version }}`
+
+### Dependencies
+
+Airline has an intentionally minimal set of dependencies, these are currently as follows:
+
+- Apache Commons Lang and Apache Commons Collections
+- Airline IO (our own internal helper library for IO)
+- Jarkarta Inject (and Javax Inject)
+   - Please see [Historical Composition](guide/practise/oop.html#historical-composition) for background
+   - These dependencies will be removed in future releases
 
 ## License
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.rvesse</groupId>
     <artifactId>airline-parent</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-docs</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <plugin.moditect>1.0.0.Beta2</plugin.moditect>
 
     <!-- Dependency Versions -->
-    <dependency.javax-inject>1.0.3</dependency.javax-inject>
+    <dependency.javax-inject>2.0.1</dependency.javax-inject>
     <dependency.junit>4.12</dependency.junit>
     <dependency.testng>6.8.8</dependency.testng>
     <dependency.commons-lang3>3.7</dependency.commons-lang3>
@@ -87,6 +87,7 @@
     <module>airline-examples</module>
     <module>airline-io</module>
     <module>airline-help</module>
+      <module>airline-backcompat-javaxinject</module>
   </modules>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.github.rvesse</groupId>
   <artifactId>airline-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.8.6-SNAPSHOT</version>
+  <version>2.9.0-SNAPSHOT</version>
 
   <name>Airline - Parent</name>
   <description>Java annotation-based framework for parsing Git like command line structures</description>


### PR DESCRIPTION
Switches to the 2.x releases of the `jakarta.inject` dependency which use
the new `jakarta.inject` package.

For backwards compatibility continue to support old `javax.inject` based
annotations. This is done by creating a `airline-backcompact-javaxinject`
module that uses the old `javax.inject` dependency so
that we can have mixtures of old and new annotations in our
applications.  This dependency change is intended to be a temporary measure
for the 2.9.x releases only, 2.10.x will mark these dependencies as `optional`
and 3.x will remove them entirely.

The `ParserMetadata` now declares the composition annotations that are 
inspected.  This defaults to using the new `@AirlineModule` annotation 
which is our own new annotation, plus maintains the existing behaviour 
(`javax.inject.Inject` or `com.google.inject.Inject`) and supports the newer
`jakarta.inject.Inject` annotation providing both forwards and backwards 
compatibility.  Advanced users can choose to fully customise the choice 
of annotations as they see fit.

Documentation around composition and dependencies has been updated
to make this as clear as possible and note the forthcoming deprecation of
the ability to use `@Inject` out of the box.

# Remaining Work

- [x] Pass through docs to update examples that use `@Inject` if necessary
- [x] Make choice of injection annotations fully customisable
   - [x] Default to existing choice
- [x] Document ability to remove `airline-backcompat-javaxinject` annotation for applications that have fully transitioned to `jakarta.inject` package
- [x] Test coverage for using custom annotations
- [x] Document new parser configuration support