### PR TITLE
Fixes #140 - Replacing Deprecated Constructor Calls for Wrapper Classes

### DIFF
--- a/airline-core/src/test/java/com/github/rvesse/airline/tests/utils/ComparatorTests.java
+++ b/airline-core/src/test/java/com/github/rvesse/airline/tests/utils/ComparatorTests.java
@@ -31,7 +31,7 @@ public class ComparatorTests {
         FloatComparator comparator = new FloatComparator();
 
         Assert.assertTrue(-1f < 0f);
-        Assert.assertTrue(new Float(-1f) < new Float(0f));
+        Assert.assertTrue(-1f < 0f);
         Assert.assertEquals(comparator.compare(-1f, 0f), -1);
     }
     
@@ -40,7 +40,7 @@ public class ComparatorTests {
         FloatComparator comparator = new FloatComparator();
 
         Assert.assertTrue(1f > 0f);
-        Assert.assertTrue(new Float(1f) > new Float(0f));
+        Assert.assertTrue(1f > 0f);
         Assert.assertEquals(comparator.compare(1f, 0f), 1);
     }
     
@@ -62,7 +62,7 @@ public class ComparatorTests {
         DoubleComparator comparator = new DoubleComparator();
 
         Assert.assertTrue(-1d < 0d);
-        Assert.assertTrue(new Double(-1d) < new Double(0d));
+        Assert.assertTrue(-1d < 0d);
         Assert.assertEquals(comparator.compare(-1d, 0d), -1);
     }
     
@@ -71,7 +71,7 @@ public class ComparatorTests {
         DoubleComparator comparator = new DoubleComparator();
 
         Assert.assertTrue(1d > 0d);
-        Assert.assertTrue(new Double(1d) > new Double(0d));
+        Assert.assertTrue(1d > 0d);
         Assert.assertEquals(comparator.compare(1d, 0d), 1);
     }
     

--- a/airline-prompts/src/test/java/com/github/rvesse/airline/prompts/AbstractPromptTests.java
+++ b/airline-prompts/src/test/java/com/github/rvesse/airline/prompts/AbstractPromptTests.java
@@ -567,7 +567,7 @@ public abstract class AbstractPromptTests {
         //@formatter:on
 
         Integer value = prompt.promptForOption(false);
-        Assert.assertEquals(value, new Integer(100));
+        Assert.assertEquals(value, 100);
     }
 
     @Test
@@ -588,7 +588,7 @@ public abstract class AbstractPromptTests {
         // As numeric option selection is disabled we should get the actual
         // value 1
         Integer value = prompt.promptForOption(false);
-        Assert.assertEquals(value, new Integer(1));
+        Assert.assertEquals(value, 1);
     }
 
     @Test
@@ -609,7 +609,7 @@ public abstract class AbstractPromptTests {
         // As numeric option selection is enabled we should get the value 100
         // because thats the value at index 1
         Integer value = prompt.promptForOption(false);
-        Assert.assertEquals(value, new Integer(100));
+        Assert.assertEquals(value, 100);
     }
 
     @Test


### PR DESCRIPTION
It's. only a suggestion, because the resulting code will only test the compiler. 